### PR TITLE
Unify controls and buttons pseudo state styles

### DIFF
--- a/packages/visage-docs/src/docs/components/forms/checkbox.mdx
+++ b/packages/visage-docs/src/docs/components/forms/checkbox.mdx
@@ -24,7 +24,10 @@ import { Checkbox } from '@byteclaw/visage';
 ### Hidden label
 
 ```jsx live=true
-<Checkbox hiddenLabel label="Hidden label" name="3" />
+<Fragment>
+  <Checkbox hiddenLabel label="Hidden label" name="3-1" />
+  <Checkbox hiddenLabel label="Hidden label" name="3-2" />
+</Fragment>
 ```
 
 ### Invalid
@@ -42,7 +45,10 @@ import { Checkbox } from '@byteclaw/visage';
 ### Disabled
 
 ```jsx live=true
-<Checkbox disabled label="Disabled checkbox" name="5" />
+<Fragment>
+  <Checkbox disabled label="Disabled checkbox" name="5" />
+  <Checkbox disabled checked label="Disabled checked checkbox" name="6" />
+</Fragment>
 ```
 
 ### Controlled

--- a/packages/visage-docs/src/docs/components/forms/radio.mdx
+++ b/packages/visage-docs/src/docs/components/forms/radio.mdx
@@ -80,5 +80,11 @@ Provide `id` and `name`. Name should be same for radio group that controls the s
 <Fragment>
   <Radio disabled label="Turn On" id="disabled-0" name="disabled-state" />
   <Radio disabled label="Turn Off" id="disabled-1" name="disabled-state" />
+  <Radio
+    disabled
+    checked
+    label="Disabled checked radio"
+    name="disabled-checked"
+  ></Radio>
 </Fragment>
 ```

--- a/packages/visage-docs/src/docs/components/forms/toggle.mdx
+++ b/packages/visage-docs/src/docs/components/forms/toggle.mdx
@@ -12,11 +12,53 @@ import { Toggle } from '@byteclaw/visage';
 
 ## Examples
 
+### Default
+
 ```jsx live=true
 <Fragment>
-  <Toggle hiddenLabel label="Checkbox label" />
   <Toggle label="Toggle label" />
+</Fragment>
+```
+
+### Invalid
+
+```jsx live=true
+<Fragment>
+  <Toggle invalid label="Toggle label" />
+</Fragment>
+```
+
+### Disabled
+
+```jsx live=true
+<Fragment>
+  <Toggle disabled label="Disabled toggle"></Toggle>
+  <Toggle disabled checked label="Disabled checked toggle"></Toggle>
+</Fragment>
+```
+
+### Read only
+
+```jsx live=true
+<Fragment>
+  <Toggle readOnly label="Read only toggle"></Toggle>
+  <Toggle readOnly checked label="Read only toggle"></Toggle>
+</Fragment>
+```
+
+### Hidden label
+
+```jsx live=true
+<Fragment>
+  <Toggle hiddenLabel label="Toggle label" />
+  <Toggle checked hiddenLabel label="Toggle label" />
+</Fragment>
+```
+
+### With state content
+
+```jsx live=true
+<Fragment>
   <Toggle leftContent="off" rightContent="on" label="Toggle label" />
-  <Toggle label="Disabled toggle" disabled />
 </Fragment>
 ```

--- a/packages/visage/src/components/Button.ts
+++ b/packages/visage/src/components/Button.ts
@@ -1,126 +1,91 @@
 import { createComponent } from '../core';
 import { booleanVariant, variant } from '../variants';
+import {
+  disabledControlStyles,
+  createControlFocusShadow,
+  createControlActiveShadow,
+  createControlHoverShadow,
+} from './shared';
 import { EmotionStyleSheet } from '../types';
 
 const variantStyles: { [key: string]: EmotionStyleSheet } = {
   danger: {
     backgroundColor: 'danger',
-    borderColor: 'danger',
     color: 'dangerText',
-    '&:not([disabled]):hover': {
-      backgroundColor: 'danger.-2',
-      borderColor: 'danger.-2',
-      color: 'dangerText.-2',
+    '&:focus': {
+      boxShadow: createControlFocusShadow('danger'),
     },
-    '&:not([disabled]):focus': {
-      backgroundColor: 'danger.-4',
-      color: 'dangerText.-4',
-    },
-    '&:not([disabled]):active': {
-      backgroundColor: 'danger.-3',
-      color: 'dangerText.-3',
+    // because we need to compose box shadow
+    '&:focus:active': {
+      // keep space before , because otherwise danger won't be mapped
+      boxShadow: createControlActiveShadow('danger'),
     },
   },
   primary: {
     backgroundColor: 'primary',
-    borderColor: 'primary',
     color: 'primaryText',
-    '&:not([disabled]):hover': {
-      backgroundColor: 'primary.-2',
-      color: 'primaryText.-2',
+    '&:focus': {
+      boxShadow: createControlFocusShadow('primary'),
     },
-    '&:not([disabled]):focus': {
-      backgroundColor: 'primary.-4',
-      color: 'primaryText.-4',
-    },
-    '&:not([disabled]):active': {
-      backgroundColor: 'primary.-3',
-      color: 'primaryText.-3',
-      outlineWidth: 2,
+    // because we need to compose box shadow
+    '&:focus:active': {
+      boxShadow: createControlActiveShadow('primary'),
     },
   },
   default: {
     backgroundColor: 'lightAccent',
     color: 'lightAccentText',
-    '&:not([disabled]):hover': {
-      backgroundColor: 'lightAccent.-2',
-      color: 'lightAccentText.-2',
-    },
-    '&:not([disabled]):focus': {
-      backgroundColor: 'lightAccent.-4',
-      color: 'lightAccentText.-4',
-    },
-    '&:not([disabled]):active': {
-      backgroundColor: 'lightAccent.-3',
-      color: 'lightAccentText.-3',
-    },
   },
 };
 const outlinedVariantStyles: { [key: string]: EmotionStyleSheet } = {
   danger: {
     backgroundColor: 'transparent',
     borderColor: 'danger',
+    borderStyle: 'solid',
+    borderWidth: 2,
     color: 'lightShadesText',
-    '&:not([disabled]):hover': {
-      borderColor: 'danger.-1',
-      outlineColor: 'danger.-1',
+    '&:focus': {
+      boxShadow: createControlFocusShadow('danger'),
     },
-    '&:not([disabled]):focus': {
-      borderColor: 'danger.-3',
-      outlineColor: 'danger.-3',
-    },
-    '&:not([disabled]):active': {
-      borderColor: 'danger.-2',
-      outlineColor: 'danger.-2',
-      outlineWidth: 2,
+    // because we need to compose box shadow
+    '&:focus:active': {
+      boxShadow: createControlActiveShadow('danger'),
     },
   },
   primary: {
     backgroundColor: 'transparent',
     borderColor: 'primary',
+    borderStyle: 'solid',
+    borderWidth: 2,
     color: 'lightShadesText',
-    '&:not([disabled]):hover': {
-      borderColor: 'primary.-1',
-      outlineColor: 'primary.-1',
+    '&:focus': {
+      boxShadow: createControlFocusShadow('primary'),
     },
-    '&:not([disabled]):focus': {
-      borderColor: 'primary.-3',
-      outlineColor: 'primary.-3',
-    },
-    '&:not([disabled]):active': {
-      borderColor: 'primary.-2',
-      outlineColor: 'primary.-2',
-      outlineWidth: 2,
+    // because we need to compose box shadow
+    '&:focus:active': {
+      boxShadow: createControlActiveShadow('primary'),
     },
   },
   default: {
     backgroundColor: 'transparent',
     borderColor: 'lightAccent',
+    borderStyle: 'solid',
+    borderWidth: 2,
     color: 'lightShadesText',
-    '&:not([disabled]):hover': {
-      borderColor: 'lightAccent.-1',
-      outlineColor: 'lightAccent.-1',
-    },
-    '&:not([disabled]):focus': {
-      borderColor: 'lightAccent.-3',
-      outlineColor: 'lightAccent.-3',
-    },
-    '&:not([disabled]):active': {
-      borderColor: 'lightAccent.-2',
-      outlineColor: 'lightAccent.-2',
-      outlineWidth: 2,
-    },
   },
 };
 const monochromeButtonVariants: EmotionStyleSheet = {
   backgroundColor: 'transparent',
   color: 'currentColor',
   borderColor: 'currentColor',
-  '&:not([disabled]):hover, &:not([disabled]):focus': {
-    outlineColor: 'currentColor',
+  borderStyle: 'solid',
+  borderWidth: 2,
+  '&:focus': {
+    boxShadow: createControlFocusShadow('currentColor'),
   },
-  '&:not([disabled]):active': {
-    outlineWidth: 2,
+  // because we need to compose box shadow
+  '&:focus:active': {
+    boxShadow: createControlActiveShadow('currentColor'),
   },
 };
 
@@ -128,10 +93,8 @@ export const Button = createComponent('button', {
   displayName: 'Button',
   defaultStyles: props => ({
     alignItems: 'center',
-    borderColor: 'transparent',
-    borderStyle: 'solid',
     borderRadius: 'controlBorderRadius',
-    borderWidth: 2,
+    border: 'none',
     color: 'primary',
     cursor: 'pointer',
     display: 'inline-flex',
@@ -143,9 +106,7 @@ export const Button = createComponent('button', {
     minHeight: '2rem',
     maxWidth: '20rem',
     m: 0.5,
-    outlineStyle: 'solid',
-    outlineColor: 'transparent',
-    outlineWidth: 1,
+    outline: 'none',
     py: 1,
     px: 2,
     position: 'relative',
@@ -154,8 +115,17 @@ export const Button = createComponent('button', {
     transitionDuration: '0.2s',
     transitionTimingFunction: 'ease-out',
     verticalAlign: 'middle',
+    '&:hover': {
+      boxShadow: createControlHoverShadow(),
+    },
     '&:focus': {
-      boxShadow: '0 0 0 3px darkAccent',
+      zIndex: 1, // for button group
+      boxShadow: createControlFocusShadow(),
+    },
+    // because we need to compose box shadow
+    '&:active:focus': {
+      zIndex: 1,
+      boxShadow: createControlActiveShadow(),
     },
     // only outlined buttons can be monochrome
     ...(props.outlined
@@ -164,10 +134,7 @@ export const Button = createComponent('button', {
         : outlinedVariantStyles[props.variant || 'default'] ||
           outlinedVariantStyles.default
       : variantStyles[props.variant || 'default'] || variantStyles.default),
-    '&[disabled]': {
-      cursor: 'not-allowed',
-      opacity: 0.2,
-    },
+    '&[disabled]': disabledControlStyles,
   }),
   variants: [
     booleanVariant('outlined', true),

--- a/packages/visage/src/components/Checkbox.tsx
+++ b/packages/visage/src/components/Checkbox.tsx
@@ -1,18 +1,23 @@
-import { useUniqueId } from '@byteclaw/use-unique-id';
 import {
   ExtractVisageComponentProps,
   VisageComponent,
 } from '@byteclaw/visage-core';
-import React, { ReactNode, forwardRef, Ref, useMemo } from 'react';
+import React, {
+  ReactNode,
+  KeyboardEvent,
+  forwardRef,
+  Ref,
+  MouseEvent,
+  useCallback,
+} from 'react';
 import { createComponent } from '../core';
 import { StyleProps } from '../types';
 import {
   visuallyHiddenStyles,
   visuallyHiddenBooleanVariant,
-  invalidControlStyles,
-  invalidControlBooleanVariant,
   disabledControlBooleanVariant,
   disabledControlStyles,
+  createControlFocusShadow,
 } from './shared';
 import { Flex } from './Flex';
 import { Svg } from './Svg';
@@ -21,18 +26,22 @@ const CheckboxControl = createComponent('input', {
   displayName: 'CheckboxControl',
   defaultStyles: {
     ...visuallyHiddenStyles,
-    // prevent blinking when clicking on already focused checkbox
-    '&[aria-invalid="true"] + div': {
-      boxShadow: '0 0 0 2px danger',
-    },
-    '&:focus + div, &:active:not([disabled]) + div': {
-      boxShadow: '0 0 0 3px darkAccent',
+    // + div means that we target CheckboxToggler
+    '&:focus + div': {
+      boxShadow: createControlFocusShadow(),
     },
     '& + div': {
-      backgroundColor: 'lightAccent',
+      backgroundColor: 'textInput',
     },
+    // set up color so svg has correct color
     '&:checked + div': {
       backgroundColor: 'primary',
+      color: 'primaryText',
+      borderColor: 'primary',
+    },
+    // because we want to see that input is invalid even if it's checked
+    '&[aria-invalid="true"] + div': {
+      borderColor: 'danger',
     },
     '& + div > svg': {
       visibility: 'hidden',
@@ -40,28 +49,26 @@ const CheckboxControl = createComponent('input', {
     '&:checked + div > svg': {
       visibility: 'visible',
     },
-    '&:disabled + div': {
-      backgroundColor: 'lightAccent',
-      opacity: 0.3,
-    },
   },
-  variants: [visuallyHiddenBooleanVariant],
 });
 
 const CheckboxLabel = createComponent('label', {
   displayName: 'CheckboxLabel',
   defaultStyles: props => ({
+    alignItems: 'flex-start',
+    cursor: 'pointer',
     display: 'flex',
+    flex: '1',
     fontSize: 'inherit',
     lineHeight: 'inherit',
-    cursor: 'pointer',
-    position: 'relative',
+    m: 0,
     outline: 'none',
+    p: 0,
+    position: 'relative',
     userSelect: 'none',
     ...(props.disabled ? disabledControlStyles : {}),
-    ...(props.invalid ? invalidControlStyles : {}),
   }),
-  variants: [invalidControlBooleanVariant, disabledControlBooleanVariant],
+  variants: [disabledControlBooleanVariant],
 });
 
 const CheckboxLabelText = createComponent('span', {
@@ -74,16 +81,33 @@ const CheckboxLabelText = createComponent('span', {
   variants: [visuallyHiddenBooleanVariant],
 });
 
-const CheckboxWrapper = createComponent('div', {
-  displayName: 'CheckboxWrapper',
+const CheckboxToggler = createComponent(Flex, {
+  displayName: 'CheckboxToggler',
+  defaultProps: {
+    'aria-hidden': true,
+    children: (
+      <Svg
+        viewBox="0 0 24 24"
+        styles={{
+          width: '1em',
+          height: '1em',
+          stroke: 'textInput',
+          strokeWidth: '2px',
+          fill: 'none',
+        }}
+      >
+        <polyline points="20 6 9 17 4 12" />
+      </Svg>
+    ),
+  },
   defaultStyles: {
-    display: 'flex',
-    flex: '1',
-    fontSize: 0,
-    lineHeight: 0,
-    alignItems: 'flex-start',
-    m: 0,
-    p: 0,
+    alignSelf: 'center',
+    transition: 'all 150ms',
+    borderColor: 'lightAccent',
+    borderRadius: '3px',
+    borderStyle: 'solid',
+    borderWidth: '2px',
+    mr: 1,
   },
 });
 
@@ -94,13 +118,6 @@ interface CheckboxProps
   label: ReactNode;
 }
 
-const togglerStyles = {
-  alignSelf: 'center',
-  transition: 'all 150ms',
-  borderRadius: '3px',
-  mr: 1,
-};
-
 export const Checkbox: VisageComponent<CheckboxProps, StyleProps> = forwardRef(
   function Checkbox(
     {
@@ -108,7 +125,7 @@ export const Checkbox: VisageComponent<CheckboxProps, StyleProps> = forwardRef(
       disabled,
       checked,
       hiddenLabel = false,
-      id: outerId,
+      id,
       invalid,
       label,
       name,
@@ -119,55 +136,40 @@ export const Checkbox: VisageComponent<CheckboxProps, StyleProps> = forwardRef(
     }: CheckboxProps,
     ref: Ref<HTMLInputElement>,
   ) {
-    const idTemplate = useUniqueId();
-    const id = useMemo(() => {
-      return outerId || `chkbx-${idTemplate}`;
-    }, [outerId, idTemplate]);
+    const preventOnToggle = useCallback(
+      (e: KeyboardEvent | MouseEvent) => {
+        if (readOnly) {
+          if ((e as any).key != null && (e as KeyboardEvent).key !== ' ') {
+            return;
+          }
+
+          e.preventDefault();
+        }
+      },
+      [readOnly],
+    );
 
     return (
-      <CheckboxWrapper styles={styles}>
-        <CheckboxLabel invalid={invalid} disabled={disabled} htmlFor={id}>
-          <CheckboxControl
-            aria-invalid={invalid}
-            defaultChecked={defaultChecked}
-            checked={checked}
-            disabled={disabled}
-            id={id}
-            name={name}
-            onKeyDown={e => {
-              if (readOnly && e.key === ' ') {
-                e.preventDefault();
-              }
-            }}
-            onClick={e => {
-              if (readOnly) {
-                e.preventDefault();
-              }
-            }}
-            onChange={onChange}
-            ref={ref}
-            readOnly={readOnly}
-            tabIndex={0}
-            type="checkbox"
-            value={value}
-          />
-          <Flex aria-hidden styles={togglerStyles}>
-            <Svg
-              viewBox="0 0 24 24"
-              styles={{
-                width: '1em',
-                height: '1em',
-                stroke: 'white',
-                strokeWidth: '2px',
-                fill: 'none',
-              }}
-            >
-              <polyline points="20 6 9 17 4 12" />
-            </Svg>
-          </Flex>
-          <CheckboxLabelText hidden={hiddenLabel}>{label}</CheckboxLabelText>
-        </CheckboxLabel>
-      </CheckboxWrapper>
+      <CheckboxLabel disabled={disabled} styles={styles}>
+        <CheckboxControl
+          aria-invalid={invalid}
+          defaultChecked={defaultChecked}
+          checked={checked}
+          disabled={disabled}
+          id={id}
+          name={name}
+          onKeyDown={preventOnToggle}
+          onClick={preventOnToggle}
+          onChange={onChange}
+          ref={ref}
+          readOnly={readOnly}
+          type="checkbox"
+          value={value}
+        />
+        <CheckboxToggler />
+        &#8203; {/* fixes height if label is hidden */}
+        <CheckboxLabelText hidden={hiddenLabel}>{label}</CheckboxLabelText>
+      </CheckboxLabel>
     );
   },
 );

--- a/packages/visage/src/components/Chip.tsx
+++ b/packages/visage/src/components/Chip.tsx
@@ -10,6 +10,7 @@ import React, {
 import { createComponent } from '../core';
 import { CloseButton } from './CloseButton';
 import { StyleProps } from '../types';
+import { createControlFocusShadow } from './shared';
 
 const ChipBase = createComponent('div', {
   displayName: 'Chip',
@@ -21,15 +22,12 @@ const ChipBase = createComponent('div', {
     display: 'inline-flex',
     p: 1,
     position: 'relative',
-    outlineColor: 'transparent',
-    outlineStyle: 'solid',
-    outlineWidth: '2px',
-    outlineOffset: '-2px',
+    outline: 'none',
     '&[data-clickable="true"]': {
       cursor: 'pointer',
     },
     '&:focus, &[aria-selected="true"]': {
-      outlineColor: 'darkAccent',
+      boxShadow: createControlFocusShadow(),
     },
   },
 });

--- a/packages/visage/src/components/FileInput.tsx
+++ b/packages/visage/src/components/FileInput.tsx
@@ -15,6 +15,7 @@ import {
   invalidControlStyles,
   invalidControlBooleanVariant,
   visuallyHiddenStyles,
+  createControlFocusShadow,
 } from './shared';
 
 const BaseFileInput = createComponent('input', {
@@ -22,7 +23,7 @@ const BaseFileInput = createComponent('input', {
   defaultStyles: {
     ...visuallyHiddenStyles,
     '&:focus + div': {
-      outlineColor: 'darkAccent',
+      boxShadow: createControlFocusShadow(),
     },
   },
 });
@@ -61,8 +62,7 @@ const FileInputControl = createComponent('div', {
     fontSize: 'inherit',
     lineHeight: 'inherit',
     overflow: 'hidden',
-    outline: '2px solid transparent',
-    outlineOffset: '-2px',
+    outline: 'none',
     m: 0,
     py: 1,
     px: 2,

--- a/packages/visage/src/components/Link.ts
+++ b/packages/visage/src/components/Link.ts
@@ -1,5 +1,10 @@
 import { createComponent } from '../core';
 import { EmotionStyleSheet } from '../types';
+import {
+  createControlActiveShadow,
+  createControlHoverShadow,
+  createControlFocusShadow,
+} from './shared';
 
 /**
  * Link component's style sheet
@@ -9,16 +14,15 @@ export const LinkStyles: EmotionStyleSheet = {
   fontSize: 'inherit',
   lineHeight: 'inherit',
   color: 'primary',
+  outline: 'none',
   '&:hover': {
-    color: 'primary.-1',
+    boxShadow: createControlHoverShadow(),
   },
   '&:focus': {
-    color: 'primary.-2',
-    outlineColor: 'primary.-2',
+    boxShadow: createControlFocusShadow(),
   },
   '&:active': {
-    color: 'primary.-3',
-    outlineColor: 'primary.-3',
+    boxShadow: createControlActiveShadow(),
   },
 };
 

--- a/packages/visage/src/components/Radio.tsx
+++ b/packages/visage/src/components/Radio.tsx
@@ -1,25 +1,25 @@
-import { useUniqueId } from '@byteclaw/use-unique-id';
 import {
   VisageComponent,
   StyleProps as VisageStyleProps,
 } from '@byteclaw/visage-core';
 import React, {
   ChangeEventHandler,
+  KeyboardEvent,
+  MouseEvent,
   ReactElement,
   ReactNode,
-  useMemo,
   forwardRef,
   Ref,
+  useCallback,
 } from 'react';
 import { createComponent } from '../core';
 import { StyleProps } from '../types';
 import {
   disabledControlStyles,
   disabledControlBooleanVariant,
-  invalidControlStyles,
-  invalidControlBooleanVariant,
   visuallyHiddenBooleanVariant,
   visuallyHiddenStyles,
+  createControlFocusShadow,
 } from './shared';
 import { Flex } from './Flex';
 import { Svg } from './Svg';
@@ -28,12 +28,8 @@ const RadioControl = createComponent('input', {
   displayName: 'RadioControl',
   defaultStyles: {
     ...visuallyHiddenStyles,
-    // prevent blinking when clicking on already focused radio
-    '&[aria-invalid="true"] + div': {
-      boxShadow: '0 0 0 2px danger',
-    },
-    '&:focus + div, &:active:not([disabled]) + div': {
-      boxShadow: '0 0 0 3px darkAccent',
+    '&:focus + div': {
+      boxShadow: createControlFocusShadow(),
     },
     '& + div': {
       backgroundColor: 'textInput',
@@ -42,17 +38,16 @@ const RadioControl = createComponent('input', {
       backgroundColor: 'primary',
       borderColor: 'primary',
     },
+    // because we want to see that input is invalid even if it's checked
+    '&[aria-invalid="true"] + div': {
+      borderColor: 'danger',
+    },
     '& + div > svg': {
       visibility: 'hidden',
     },
     '&:checked + div > svg': {
       visibility: 'visible',
-      fill: 'white',
-    },
-    '&:disabled + div, &:disabled + div > svg': {
-      borderColor: 'lightAccent',
-      fill: 'lightAccent',
-      opacity: 0.3,
+      fill: 'textInput',
     },
   },
 });
@@ -60,17 +55,20 @@ const RadioControl = createComponent('input', {
 const RadioLabel = createComponent('label', {
   displayName: 'RadioLabel',
   defaultStyles: props => ({
+    alignItems: 'flex-start',
+    cursor: 'pointer',
     display: 'flex',
+    flex: '1',
     fontSize: 'inherit',
     lineHeight: 'inherit',
-    cursor: 'pointer',
-    position: 'relative',
+    m: 0,
     outline: 'none',
+    p: 0,
+    position: 'relative',
     userSelect: 'none',
     ...(props.disabled ? disabledControlStyles : {}),
-    ...(props.invalid ? invalidControlStyles : {}),
   }),
-  variants: [disabledControlBooleanVariant, invalidControlBooleanVariant],
+  variants: [disabledControlBooleanVariant],
 });
 
 const RadioLabelText = createComponent('span', {
@@ -83,29 +81,33 @@ const RadioLabelText = createComponent('span', {
   variants: [visuallyHiddenBooleanVariant],
 });
 
-const RadioWrapper = createComponent('div', {
-  displayName: 'RadioWrapper',
+const RadioToggler = createComponent(Flex, {
+  displayName: 'RadioToggler',
+  defaultProps: {
+    'aria-hidden': true,
+    children: (
+      <Svg
+        viewBox="0 0 24 24"
+        styles={{
+          width: '1em',
+          height: '1em',
+        }}
+      >
+        <circle cx="12" cy="12" r="6" />
+      </Svg>
+    ),
+  },
   defaultStyles: {
-    display: 'flex',
-    flex: '1',
-    fontSize: 0,
-    lineHeight: 0,
-    alignItems: 'flex-start',
-    m: 0,
-    p: 0,
+    background: 'rgba(255,255,255,0.3)',
+    alignSelf: 'center',
+    transition: 'all 150ms',
+    borderRadius: 999,
+    borderStyle: 'solid',
+    borderWidth: '2px',
+    borderColor: 'lightAccent',
+    mr: 1,
   },
 });
-
-const togglerStyles = {
-  background: 'rgba(255,255,255,0.3)',
-  alignSelf: 'center',
-  transition: 'all 150ms',
-  borderRadius: 999,
-  borderStyle: 'solid',
-  borderWidth: '2px',
-  borderColor: 'lightAccent',
-  mr: 1,
-};
 
 interface RadioProps extends VisageStyleProps<StyleProps> {
   checked?: boolean;
@@ -132,7 +134,7 @@ export const Radio: VisageComponent<RadioProps, StyleProps> = forwardRef(
       defaultChecked,
       disabled,
       hiddenLabel = false,
-      id: outerId,
+      id,
       invalid,
       label,
       name,
@@ -143,51 +145,39 @@ export const Radio: VisageComponent<RadioProps, StyleProps> = forwardRef(
     }: RadioProps,
     ref: Ref<HTMLInputElement>,
   ) {
-    const idTemplate = useUniqueId();
-    const id = useMemo(() => {
-      return outerId || `chkbx-${idTemplate}-${name || ''}`;
-    }, [outerId, idTemplate]);
+    const preventOnToggle = useCallback(
+      (e: KeyboardEvent | MouseEvent) => {
+        if (readOnly) {
+          if ((e as any).key != null && (e as KeyboardEvent).key !== ' ') {
+            return;
+          }
+
+          e.preventDefault();
+        }
+      },
+      [readOnly],
+    );
 
     return (
-      <RadioWrapper styles={styles}>
-        <RadioLabel disabled={disabled} invalid={invalid} htmlFor={id}>
-          <RadioControl
-            aria-invalid={invalid}
-            defaultChecked={defaultChecked}
-            checked={checked}
-            disabled={disabled}
-            id={id}
-            name={name}
-            onChange={onChange}
-            onClick={e => {
-              if (readOnly) {
-                e.preventDefault();
-              }
-            }}
-            onKeyDown={e => {
-              if (readOnly && e.key === ' ') {
-                e.preventDefault();
-              }
-            }}
-            ref={ref}
-            tabIndex={disabled ? -1 : 0}
-            type="radio"
-            value={value}
-          />
-          <Flex aria-hidden styles={togglerStyles}>
-            <Svg
-              viewBox="0 0 24 24"
-              styles={{
-                width: '1em',
-                height: '1em',
-              }}
-            >
-              <circle cx="12" cy="12" r="6" />
-            </Svg>
-          </Flex>
-          <RadioLabelText hidden={hiddenLabel}>{label}</RadioLabelText>
-        </RadioLabel>
-      </RadioWrapper>
+      <RadioLabel disabled={disabled} styles={styles}>
+        <RadioControl
+          aria-invalid={invalid}
+          defaultChecked={defaultChecked}
+          checked={checked}
+          disabled={disabled}
+          id={id}
+          name={name}
+          onChange={onChange}
+          onClick={preventOnToggle}
+          onKeyDown={preventOnToggle}
+          ref={ref}
+          type="radio"
+          value={value}
+        />
+        <RadioToggler />
+        &#8203; {/* fixes height if label is hidden */}
+        <RadioLabelText hidden={hiddenLabel}>{label}</RadioLabelText>
+      </RadioLabel>
     );
   },
 );

--- a/packages/visage/src/components/TextInput.tsx
+++ b/packages/visage/src/components/TextInput.tsx
@@ -35,7 +35,7 @@ export const TextInputBaseStyles: EmotionStyleSheet = {
   position: 'relative',
   // data-focused is used by text input on base
   '&:focus, &[data-focused="true"]': {
-    boxShadow: '0 0 0 3px lightAccent',
+    boxShadow: '0 0 0 4px rgba(255, 255, 255, 0.4), 0 0 0 4px lightAccent',
   },
 };
 

--- a/packages/visage/src/components/__tests__/Chip.test.tsx
+++ b/packages/visage/src/components/__tests__/Chip.test.tsx
@@ -44,10 +44,7 @@ describe('Chip', () => {
         display: inline-flex;
         padding: 8px;
         position: relative;
-        outline-color: transparent;
-        outline-style: solid;
-        outline-width: 2px;
-        outline-offset: -2px;
+        outline: none;
       }
 
       .emotion-0[data-clickable="true"] {
@@ -56,7 +53,7 @@ describe('Chip', () => {
 
       .emotion-0:focus,
       .emotion-0[aria-selected="true"] {
-        outline-color: darkAccent;
+        box-shadow: 0 0 0 4px rgba(255,255,255,0.4),0 0 0 4px lightAccent ,inset 0 0 200px rgba(68,68,68,0.1);
       }
 
       <div

--- a/packages/visage/src/components/shared/variants.ts
+++ b/packages/visage/src/components/shared/variants.ts
@@ -1,6 +1,25 @@
 import { booleanVariant } from '../../variants';
 import { EmotionStyleSheet } from '../../types';
 
+/**
+ * Control focus shadow that is used to compose actual focus shadow (needs a color at the end)
+ *
+ * The white color works as some sort of opacity
+ */
+export const controlFocusShadow =
+  '0 0 0 4px rgba(255, 255, 255, 0.4), 0 0 0 4px';
+export const controlHoverShadow = 'inset 0 0 200px rgba(68, 68, 68, 0.1)';
+export const controlActiveShadow =
+  'inset 0 0 200px rgba(68, 68, 68, 0.2), inset 0 0 2px rgba(0, 0, 0, 0.2)';
+
+export const createControlFocusShadow = (
+  color: string = 'lightAccent',
+): string => `${controlFocusShadow} ${color} , ${controlHoverShadow}`;
+export const createControlHoverShadow = (): string => controlHoverShadow;
+export const createControlActiveShadow = (
+  color: string = 'lightAccent',
+): string => `${controlFocusShadow} ${color} , ${controlActiveShadow}`;
+
 export const visuallyHiddenStyles: EmotionStyleSheet = {
   border: '0',
   clip: 'rect(0, 0, 0, 0)',
@@ -14,20 +33,11 @@ export const visuallyHiddenStyles: EmotionStyleSheet = {
 };
 
 export const disabledControlStyles: EmotionStyleSheet = {
-  color: 'neutral.1',
-  cursor: 'not-allowed',
-  outlineColor: 'neutral.1',
+  cursor: 'default',
+  pointerEvents: 'none',
   // applicable to textarea
   resize: 'none',
-  // checkbox, radio
-  '&::before': {
-    borderColor: 'neutral.1',
-  },
-  // checkbox, radio
-  '&::after': {
-    borderColor: 'neutral.1',
-  },
-  opacity: 0.3,
+  opacity: 0.5,
 };
 
 export const invalidControlStyles: EmotionStyleSheet = {


### PR DESCRIPTION
TODO:

- [x] - AutocompleteInput
- [x] - Button
- [x] - Checkbox (needs same focus styles as Button/Select)
- [x] - Chip
- [x] - CloseButton
- [x] - FileInput
- [x] - Radio (needs same focus styles as Button/Select)
- [x] - Select
- [x] - TextArea
- [x] - TextInput
- [x] - Toggle (needs same focus styles as Button/Select)

**All focusable, hoverable, pressable elements must have the same logic to visually communicate their states**

Closes #233 