### PR TITLE
Register close listeners on render and not on mount

### DIFF
--- a/packages/visage/src/__tests__/CloseListenerManager.test.tsx
+++ b/packages/visage/src/__tests__/CloseListenerManager.test.tsx
@@ -1,0 +1,264 @@
+/* eslint-disable no-shadow */
+import { act, fireEvent, render } from '@testing-library/react';
+import React, { useContext, useState, ReactElement, useRef } from 'react';
+import {
+  CloseListenerManager,
+  CloseListenerManagerContext,
+} from '../CloseListenerManager';
+import { useOnRenderEffect } from '../hooks';
+
+function RenderClosable({
+  children,
+  id,
+  isFullscreen,
+  onClose,
+}: {
+  children?: (onClose: () => void) => ReactElement;
+  id: string;
+  isFullscreen?: boolean;
+  onClose(e: Event): void;
+}) {
+  const divRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(true);
+  const closeListenerManager = useContext(CloseListenerManagerContext);
+
+  useOnRenderEffect(() => {
+    const unregisterEscape = closeListenerManager.registerEscapeKeyDownListener(
+      onClose,
+    );
+    const unregisterClick = closeListenerManager.registerClickAwayListener(
+      divRef,
+      onClose,
+      isFullscreen,
+    );
+
+    return () => {
+      unregisterEscape();
+      unregisterClick();
+    };
+  }, [closeListenerManager]);
+
+  return (
+    <div ref={divRef}>
+      <React.Fragment>
+        <div data-testid={id} />
+        {open && children ? children(() => setOpen(false)) : null}
+      </React.Fragment>
+    </div>
+  );
+}
+
+jest.setTimeout(10000);
+
+describe('CloseListenerManager', () => {
+  describe('escape key down', () => {
+    it('registers escape key down handler', () => {
+      // close listener manager must be used in nested way and not as siblings otherwise
+      // it will behave incorrectly
+      const onRootClose = jest.fn();
+      const { getByTestId } = render(
+        <CloseListenerManager>
+          <RenderClosable id="1" onClose={onRootClose}>
+            {onClose => (
+              <RenderClosable id="2" onClose={onClose}>
+                {onClose => (
+                  <RenderClosable id="3" onClose={onClose}>
+                    {onClose => <RenderClosable id="4" onClose={onClose} />}
+                  </RenderClosable>
+                )}
+              </RenderClosable>
+            )}
+          </RenderClosable>
+        </CloseListenerManager>,
+      );
+
+      expect(getByTestId('4')).toBeDefined();
+      expect(getByTestId('3')).toBeDefined();
+      expect(getByTestId('2')).toBeDefined();
+      expect(getByTestId('1')).toBeDefined();
+
+      // fire escape keydown
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(() => getByTestId('4')).toThrow();
+      expect(getByTestId('3')).toBeDefined();
+      expect(getByTestId('2')).toBeDefined();
+      expect(getByTestId('1')).toBeDefined();
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(() => getByTestId('3')).toThrow();
+      expect(getByTestId('2')).toBeDefined();
+      expect(getByTestId('1')).toBeDefined();
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(() => getByTestId('2')).toThrow();
+      expect(getByTestId('1')).toBeDefined();
+
+      expect(onRootClose).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onRootClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('click away', () => {
+    it('registers as fullscreen by default (prevents bubbling to shallower layers)', async () => {
+      // close listener manager must be used in nested way and not as siblings otherwise
+      // it will behave incorrectly
+      const onRootClose = jest.fn();
+      const { getByTestId } = render(
+        <CloseListenerManager>
+          <RenderClosable id="1" onClose={onRootClose}>
+            {onClose => (
+              <RenderClosable id="2" onClose={onClose}>
+                {onClose => (
+                  <RenderClosable id="3" onClose={onClose}>
+                    {onClose => <RenderClosable id="4" onClose={onClose} />}
+                  </RenderClosable>
+                )}
+              </RenderClosable>
+            )}
+          </RenderClosable>
+        </CloseListenerManager>,
+      );
+
+      expect(getByTestId('4')).toBeDefined();
+      expect(getByTestId('3')).toBeDefined();
+      expect(getByTestId('2')).toBeDefined();
+      expect(getByTestId('1')).toBeDefined();
+
+      // fire click away (closes only fullscreen layer and doesn't go further)
+      fireEvent.click(document);
+
+      expect(() => getByTestId('4')).toThrow();
+      expect(getByTestId('3')).toBeDefined();
+      expect(getByTestId('2')).toBeDefined();
+      expect(getByTestId('1')).toBeDefined();
+
+      fireEvent.click(document);
+
+      expect(() => getByTestId('3')).toThrow();
+      expect(getByTestId('2')).toBeDefined();
+      expect(getByTestId('1')).toBeDefined();
+
+      fireEvent.click(document);
+
+      expect(() => getByTestId('2')).toThrow();
+      expect(getByTestId('1')).toBeDefined();
+
+      expect(onRootClose).not.toHaveBeenCalled();
+
+      fireEvent.click(document);
+
+      expect(onRootClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows to define layers as not fullscreen (bubble to shallower levels)', async () => {
+      // close listener manager must be used in nested way and not as siblings otherwise
+      // it will behave incorrectly
+      const onRootClose = jest.fn();
+      const { getByTestId } = render(
+        <CloseListenerManager>
+          <RenderClosable id="1" onClose={onRootClose}>
+            {onClose => (
+              <RenderClosable id="2" onClose={onClose}>
+                {onClose => (
+                  <RenderClosable id="3" isFullscreen={false} onClose={onClose}>
+                    {onClose => (
+                      <RenderClosable
+                        id="4"
+                        isFullscreen={false}
+                        onClose={onClose}
+                      />
+                    )}
+                  </RenderClosable>
+                )}
+              </RenderClosable>
+            )}
+          </RenderClosable>
+        </CloseListenerManager>,
+      );
+
+      expect(getByTestId('4')).toBeDefined();
+      expect(getByTestId('3')).toBeDefined();
+      expect(getByTestId('2')).toBeDefined();
+      expect(getByTestId('1')).toBeDefined();
+
+      // fire click away layer 4 and 3 are not fullscreen so on close bubbles to layer 2 inclusive
+      await act(async () => fireEvent.click(document));
+
+      expect(() => getByTestId('4')).toThrow();
+      expect(() => getByTestId('3')).toThrow();
+      expect(() => getByTestId('2')).toThrow();
+      expect(getByTestId('1')).toBeDefined();
+
+      expect(onRootClose).not.toHaveBeenCalled();
+
+      fireEvent.click(document);
+
+      expect(onRootClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows bubbling to be prevented', async () => {
+      // close listener manager must be used in nested way and not as siblings otherwise
+      // it will behave incorrectly
+      const onRootClose = jest.fn();
+      let close4 = 0;
+      const { getByTestId } = render(
+        <CloseListenerManager>
+          <RenderClosable id="1" onClose={onRootClose}>
+            {onClose => (
+              <RenderClosable id="2" onClose={onClose}>
+                {onClose => (
+                  <RenderClosable id="3" isFullscreen={false} onClose={onClose}>
+                    {onClose => (
+                      <RenderClosable
+                        id="4"
+                        isFullscreen={false}
+                        onClose={e => {
+                          if (close4 === 0) {
+                            e.preventDefault();
+                            close4++;
+                          } else {
+                            onClose();
+                          }
+                        }}
+                      />
+                    )}
+                  </RenderClosable>
+                )}
+              </RenderClosable>
+            )}
+          </RenderClosable>
+        </CloseListenerManager>,
+      );
+
+      expect(getByTestId('4')).toBeDefined();
+      expect(getByTestId('3')).toBeDefined();
+      expect(getByTestId('2')).toBeDefined();
+      expect(getByTestId('1')).toBeDefined();
+
+      // first click away is prevented so nothing happens
+      fireEvent.click(document);
+
+      expect(getByTestId('4')).toBeDefined();
+
+      // fire click away layer 4 and 3 are not fullscreen so on close bubbles to layer 2 inclusive
+      await act(async () => fireEvent.click(document));
+
+      expect(() => getByTestId('4')).toThrow();
+      expect(() => getByTestId('3')).toThrow();
+      expect(() => getByTestId('2')).toThrow();
+      expect(getByTestId('1')).toBeDefined();
+
+      expect(onRootClose).not.toHaveBeenCalled();
+
+      fireEvent.click(document);
+
+      expect(onRootClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/visage/src/components/Modal.tsx
+++ b/packages/visage/src/components/Modal.tsx
@@ -14,7 +14,7 @@ import { Portal } from './Portal';
 import {
   useAutofocusOnMount,
   useFocusTrap,
-  useStaticEffect,
+  useStaticOnRenderEffect,
   useUniqueId,
 } from '../hooks';
 import {
@@ -146,7 +146,7 @@ export function Modal({
 
   useFocusTrap(contentRef || modalRef, focusElementRef);
   useAutofocusOnMount(focusElementRef);
-  useStaticEffect(
+  useStaticOnRenderEffect(
     bindOnCloseListeners,
     open,
     closeListenerManagerContext,

--- a/packages/visage/src/hooks/__tests__/useOnRenderEffect.test.ts
+++ b/packages/visage/src/hooks/__tests__/useOnRenderEffect.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useOnRenderEffect } from '../useOnRenderEffect';
+
+describe('useOnRenderEffect', () => {
+  it('calls effect on component render and cleans it up on every rerender', () => {
+    const cleanupEffect = jest.fn();
+    const effect = jest.fn().mockImplementation(() => cleanupEffect);
+
+    const result = renderHook(() => useOnRenderEffect(effect));
+
+    expect(effect).toHaveBeenCalledTimes(1);
+    expect(cleanupEffect).not.toHaveBeenCalled();
+
+    result.rerender();
+
+    expect(effect).toHaveBeenCalledTimes(2);
+    // because effect always returns the same function so useEffect does not do anything
+    expect(cleanupEffect).toHaveBeenCalledTimes(0);
+
+    result.unmount();
+
+    expect(effect).toHaveBeenCalledTimes(2);
+    expect(cleanupEffect).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls effect on component render and cleans it up on prop change', () => {
+    const cleanupEffect = jest.fn();
+    const effect = jest.fn().mockImplementation(() => cleanupEffect);
+
+    const result = renderHook(props => useOnRenderEffect(effect, [props.a]), {
+      initialProps: { a: 10 },
+    });
+
+    expect(effect).toHaveBeenCalledTimes(1);
+    expect(cleanupEffect).not.toHaveBeenCalled();
+
+    result.rerender();
+
+    expect(effect).toHaveBeenCalledTimes(1);
+    expect(cleanupEffect).not.toHaveBeenCalled();
+
+    result.rerender({ a: 20 });
+
+    expect(effect).toHaveBeenCalledTimes(2);
+    // is not called because unregister is always the same in our case
+    expect(cleanupEffect).toHaveBeenCalledTimes(0);
+
+    result.rerender({ a: 20 });
+
+    expect(effect).toHaveBeenCalledTimes(2);
+    // is not called because unregister is always the same in our case
+    expect(cleanupEffect).toHaveBeenCalledTimes(0);
+
+    result.unmount();
+
+    expect(effect).toHaveBeenCalledTimes(2);
+    expect(cleanupEffect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/visage/src/hooks/index.ts
+++ b/packages/visage/src/hooks/index.ts
@@ -3,5 +3,6 @@ export * from './useBreakpointDetection';
 export * from './useDebouncedCallback';
 export * from './useFocusTrap';
 export * from './useHandlerRef';
+export * from './useOnRenderEffect';
 export * from './useStaticEffect';
 export * from './useUniqueId';

--- a/packages/visage/src/hooks/useOnRenderEffect.ts
+++ b/packages/visage/src/hooks/useOnRenderEffect.ts
@@ -1,0 +1,31 @@
+import { useEffect, useMemo } from 'react';
+import { ExtractArgs } from '@byteclaw/visage-core';
+
+/**
+ * Works similarly as useEffect except it runs effect before children are rendered
+ * And then cleans them up in same order as useEffect works
+ *
+ * So basically mount works from parent to child and unmount in opposite order
+ */
+export function useOnRenderEffect(
+  effect: () => void | (() => void),
+  dependencies?: any[],
+) {
+  const unregister = useMemo(effect, dependencies);
+
+  useEffect(() => unregister, [unregister]);
+}
+
+/**
+ * Works similarly as useEffect except it runs effect before children are rendered
+ * And then cleans them up in same order as useEffect works
+ *
+ * So basically mount works from parent to child and unmount in opposite order
+ */
+export function useStaticOnRenderEffect<
+  T extends (...args: any[]) => void | (() => void)
+>(effect: T, ...args: ExtractArgs<T>) {
+  const unregister = useMemo(() => effect(...args), [effect, ...args]);
+
+  useEffect(() => unregister, [unregister]);
+}


### PR DESCRIPTION
This PR introduces a way to prevent bubbling `onClose` listeners in `CloseListenerManager` and also adds a support for async `onClose` listeners.

Also new hooks `useOnRenderEffect` and `useStaticOnRenderEffect` are introduced to fix the problem where `useEffect` is called in order from `child -> parent` and we need to register close listeners in order `parent -> child`.

I'm not sure if React always calls `useEffect` or if there are cases where `useEffect` is not called at all but `useMemo` is (for example rapid rendering where parent quickly decides that it doesn't need child?

Closes #340 