### PR TITLE
feat(visage): lock body scroll and add focus trap to Drawer

### DIFF
--- a/packages/visage-docs/src/components/CodeBlock.tsx
+++ b/packages/visage-docs/src/components/CodeBlock.tsx
@@ -2,7 +2,16 @@
 import Highlight, { defaultProps, Language } from 'prism-react-renderer';
 import duotoneLight from 'prism-react-renderer/themes/duotoneLight';
 import duotoneDark from 'prism-react-renderer/themes/duotoneDark';
-import React, { Fragment, useContext, useState } from 'react';
+import React, {
+  Fragment,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react';
 import { LiveEditor, LiveError, LivePreview, LiveProvider } from 'react-live';
 import * as DSScope from '@byteclaw/visage';
 import * as Core from '@byteclaw/visage-core';
@@ -17,6 +26,13 @@ const Scope = {
   ...Core,
   ...DSScope,
   ...Utilities,
+  useState,
+  useContext,
+  useReducer,
+  useRef,
+  useEffect,
+  useMemo,
+  useCallback,
   WithRef,
   WithState,
 };
@@ -34,6 +50,7 @@ interface CodeBlockProps {
   className: string;
   children: string;
   live?: boolean;
+  noInline?: boolean;
   expanded?: boolean;
   stringify?: boolean;
   transpile?: boolean | 'false' | 'true';
@@ -44,6 +61,7 @@ export function CodeBlock({
   className: baseClassName,
   live,
   expanded,
+  noInline,
   stringify,
   transpile = true,
 }: CodeBlockProps) {
@@ -60,6 +78,7 @@ export function CodeBlock({
           disabled={!live}
           language={language}
           transformCode={stringify ? code => `'' + ${code}` : undefined}
+          noInline={noInline}
           scope={Scope}
           theme={duotoneLight}
         >

--- a/packages/visage-docs/src/components/Layout.tsx
+++ b/packages/visage-docs/src/components/Layout.tsx
@@ -27,6 +27,7 @@ export function Layout({ children }: Props) {
   return (
     <React.Fragment>
       <Drawer
+        backdrop={false}
         styles={{
           width: '16rem',
           flexShrink: 0,

--- a/packages/visage-docs/src/docs/components/overlays/drawer.mdx
+++ b/packages/visage-docs/src/docs/components/overlays/drawer.mdx
@@ -14,36 +14,35 @@ import { Drawer } from '@byteclaw/visage';
 
 ### Default
 
-Default drawer is rendered with `position: fixed`.
+Default drawer is rendered in place with `position: fixed` and locks body scroll.
 
 ```jsx live=true
-<WithState defaultValue={false}>
-  {(show, setShow) => {
-    if (!show) {
-      return (
-        <Button onClick={() => setShow(true)} type="button">
-          Show drawer
-        </Button>
-      );
-    }
+function DefaultDrawer() {
+  const [show, setShow] = useState(false);
 
-    return (
-      <Drawer
-        onClose={e => {
-          console.log(e);
-          setShow(false);
-        }}
-        open={show}
-      >
-        {Array(20)
-          .fill(null)
-          .map((_, i) => (
-            <ParagraphSkeleton key={i} />
-          ))}
-      </Drawer>
-    );
-  }}
-</WithState>
+  return (
+    <>
+      <Button onClick={() => setShow(true)} type="button">
+        Show drawer
+      </Button>
+      {show ? (
+        <Drawer
+          onClose={e => {
+            console.log(e);
+            setShow(false);
+          }}
+          open={show}
+        >
+          {Array(20)
+            .fill(null)
+            .map((_, i) => (
+              <ParagraphSkeleton key={i} />
+            ))}
+        </Drawer>
+      ) : null}
+    </>
+  );
+}
 ```
 
 ### Custom render side
@@ -51,30 +50,30 @@ Default drawer is rendered with `position: fixed`.
 To control a side where `Drawer` is rendered, use `side` prop. Possible values are `bottm, left, right, top`
 
 ```jsx live=true
-<WithState defaultValue={false}>
-  {(show, setShow) => {
-    if (!show) {
-      return (
-        <Button onClick={() => setShow(true)} type="button">
-          Show drawer
-        </Button>
-      );
-    }
+function CustomRenderSide() {
+  const [show, setShow] = useState(false);
 
-    return (
-      <Drawer
-        onClose={e => {
-          console.log(e);
-          setShow(false);
-        }}
-        open={show}
-        side={DrawerPosition.bottom}
-      >
-        Drawer content
-      </Drawer>
-    );
-  }}
-</WithState>
+  return (
+    <>
+      <Button onClick={() => setShow(true)} type="button">
+        Show drawer
+      </Button>
+      {show ? (
+        <Drawer
+          inPortal
+          onClose={e => {
+            console.log(e);
+            setShow(false);
+          }}
+          open={show}
+          side={DrawerPosition.bottom}
+        >
+          Drawer content
+        </Drawer>
+      ) : null}
+    </>
+  );
+}
 ```
 
 ### Render to Portal
@@ -82,30 +81,29 @@ To control a side where `Drawer` is rendered, use `side` prop. Possible values a
 If you want to render `Drawer` in `Portal`, use `inPortal` prop.
 
 ```jsx live=true
-<WithState defaultValue={false}>
-  {(show, setShow) => {
-    if (!show) {
-      return (
-        <Button onClick={() => setShow(true)} type="button">
-          Show drawer
-        </Button>
-      );
-    }
+function RenderToPortal() {
+  const [show, setShow] = useState(false);
 
-    return (
-      <Drawer
-        inPortal
-        onClose={e => {
-          console.log(e);
-          setShow(false);
-        }}
-        open={show}
-      >
-        Drawer content
-      </Drawer>
-    );
-  }}
-</WithState>
+  return (
+    <>
+      <Button onClick={() => setShow(true)} type="button">
+        Show drawer
+      </Button>
+      {show ? (
+        <Drawer
+          inPortal
+          onClose={e => {
+            console.log(e);
+            setShow(false);
+          }}
+          open={show}
+        >
+          Drawer content
+        </Drawer>
+      ) : null}
+    </>
+  );
+}
 ```
 
 ### Relative
@@ -116,32 +114,97 @@ If you want to render `Drawer` in `Portal`, use `inPortal` prop.
 
 ### Disable backdrop
 
-`Drawer's` backdrop can be disabled using `backdrop={false}`. `Drawer` without `Backdrop` can be closed only by `Escape` or by setting `open` prop to `false`.
+`Drawer` backdrop can be disabled using `backdrop={false}` and it also doesn't lock the body scroll.
 
 ```jsx live=true
-<WithState defaultValue={false}>
-  {(show, setShow) => {
-    if (!show) {
-      return (
-        <Button onClick={() => setShow(true)} type="button">
-          Show drawer
-        </Button>
-      );
-    }
+function DisableBackdrop() {
+  const [show, setShow] = useState(false);
 
-    return (
-      <Drawer
-        backdrop={false}
-        inPortal
-        onClose={e => {
-          console.log(e);
-          setShow(false);
-        }}
-        open={show}
-      >
-        Drawer content
-      </Drawer>
-    );
-  }}
-</WithState>
+  return (
+    <>
+      <Button onClick={() => setShow(true)} type="button">
+        Show drawer
+      </Button>
+      {show ? (
+        <Drawer
+          backdrop={false}
+          inPortal
+          onClose={e => {
+            console.log(e);
+            setShow(false);
+          }}
+          open={show}
+        >
+          Drawer content
+        </Drawer>
+      ) : null}
+    </>
+  );
+}
+```
+
+### Disable backdrop and click away
+
+```jsx live=true
+function DisableBackdropAndClickAway() {
+  const [show, setShow] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setShow(true)} type="button">
+        Show drawer
+      </Button>
+      {show ? (
+        <Drawer
+          backdrop={false}
+          inPortal
+          onClose={e => {
+            console.log(e);
+
+            if (!(e instanceof MouseEvent)) {
+              setShow(false);
+            }
+          }}
+          open={show}
+        >
+          Drawer content
+        </Drawer>
+      ) : null}
+    </>
+  );
+}
+```
+
+### Automatically focus element in Drawer on open
+
+By providing `focusElementRef` prop you tell `Drawer` to automaticaly focus this element when Drawer is open.
+This also tells the focus trap to focus this element if Drawer loses focus.
+
+```jsx live=true
+function AutomaticallyFocusElementInDrawer() {
+  const [show, setShow] = useState(false);
+  const buttonRef = useRef(null);
+
+  return (
+    <>
+      <Button onClick={() => setShow(true)} type="button">
+        Show drawer
+      </Button>
+      {show ? (
+        <Drawer
+          inPortal
+          onClose={() => setShow(false)}
+          open={show}
+          focusElementRef={buttonRef}
+        >
+          <Button ref={buttonRef} type="button">
+            1
+          </Button>
+          <Button type="button">2</Button>
+          <Button type="button">3</Button>
+        </Drawer>
+      ) : null}
+    </>
+  );
+}
 ```

--- a/packages/visage/src/CloseListenerManager.tsx
+++ b/packages/visage/src/CloseListenerManager.tsx
@@ -5,11 +5,14 @@ import React, {
   ReactNode,
   RefObject,
   createContext,
+  useContext,
   useRef,
 } from 'react';
 import { useStaticEffect } from './hooks';
 
-type OnCloseHandler = (e: Event) => any | Promise<any>;
+export type OnCloseHandler = (
+  e: KeyboardEvent | MouseEvent,
+) => any | Promise<any>;
 
 interface ClickAwayHandler {
   ref: RefObject<HTMLElement>;
@@ -50,6 +53,13 @@ export const CloseListenerManagerContext = createContext<
     return () => {};
   },
 });
+
+/**
+ * Connects to CloseListenerManager
+ */
+export function useCloseListenerManager(): CloseListenerManagerContextAPI {
+  return useContext(CloseListenerManagerContext);
+}
 
 function onEscapeKeyDownHandlerCreator(
   escapeStack: MutableRefObject<OnCloseHandler[]>,

--- a/packages/visage/src/components/Modal.tsx
+++ b/packages/visage/src/components/Modal.tsx
@@ -3,10 +3,8 @@ import React, {
   useRef,
   MutableRefObject,
   useContext,
-  useEffect,
   RefObject,
 } from 'react';
-import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
 import { createComponent } from '../core';
 import { booleanVariant } from '../variants';
 import { LayerManager, useLayerManager } from './LayerManager';
@@ -15,12 +13,14 @@ import {
   useAutofocusOnMount,
   useFocusTrap,
   useStaticOnRenderEffect,
+  useStaticEffect,
   useUniqueId,
 } from '../hooks';
 import {
   CloseListenerManagerContext,
   CloseListenerManagerContextAPI,
 } from '../CloseListenerManager';
+import { disableBodyScroll } from './effects';
 
 const BaseModal = createComponent('div', {
   displayName: 'Modal',
@@ -156,20 +156,7 @@ export function Modal({
     disableOnClickAwayClose,
     disableOnEscapeClose,
   );
-
-  useEffect(() => {
-    const { current } = modalRef;
-
-    if (!current || !open || unlockBodyScroll) {
-      return;
-    }
-
-    disableBodyScroll(current);
-
-    return () => {
-      enableBodyScroll(current);
-    };
-  }, [unlockBodyScroll, open, modalRef.current]);
+  useStaticEffect(disableBodyScroll, modalRef, !unlockBodyScroll && open);
 
   if (typeof document === 'undefined' || !open) {
     return null;

--- a/packages/visage/src/components/effects/index.ts
+++ b/packages/visage/src/components/effects/index.ts
@@ -1,8 +1,12 @@
+import {
+  enableBodyScroll as unlockBodyScroll,
+  disableBodyScroll as lockBodyScroll,
+} from 'body-scroll-lock';
 import { RefObject } from 'react';
 
 /** Scrolls aria-selected="true" child of container identified by ref into view */
 export function scrollAriaSelectedElementToView(
-  containerRef: RefObject<HTMLDivElement>,
+  containerRef: RefObject<HTMLElement>,
   // we don't use this but we need this for effect to be invoked
   // eslint-disable-next-line
   index: number,
@@ -13,4 +17,20 @@ export function scrollAriaSelectedElementToView(
       block: 'nearest',
       inline: 'start',
     });
+}
+
+/**
+ * Disables body scroll if disabled is true
+ */
+export function disableBodyScroll(
+  { current }: RefObject<HTMLElement>,
+  disabled: boolean,
+) {
+  if (!disabled || !current) {
+    return;
+  }
+
+  lockBodyScroll(current);
+
+  return () => unlockBodyScroll(current);
 }

--- a/packages/visage/src/hooks/useAutofocusOnMount.ts
+++ b/packages/visage/src/hooks/useAutofocusOnMount.ts
@@ -6,8 +6,10 @@ function focusElementOnMount(
     | null
     | undefined
     | React.RefObject<HTMLElement | null | undefined>,
+  /** Should we focus element? */
+  focus: boolean,
 ) {
-  if (elementToFocusRef && elementToFocusRef.current) {
+  if (focus && elementToFocusRef && elementToFocusRef.current) {
     elementToFocusRef.current.focus();
   }
 }
@@ -15,6 +17,10 @@ function focusElementOnMount(
 /**
  * Autofocuses element on mount
  */
-export function useAutofocusOnMount(ref?: null | RefObject<HTMLElement>) {
-  useStaticEffect(focusElementOnMount, ref);
+export function useAutofocusOnMount(
+  ref?: null | RefObject<HTMLElement>,
+  /** Should we focus element? */
+  focus: boolean = true,
+) {
+  useStaticEffect(focusElementOnMount, ref, focus);
 }

--- a/packages/visage/src/variants.ts
+++ b/packages/visage/src/variants.ts
@@ -5,6 +5,7 @@ import { EmotionStyleSheet } from './types';
  */
 export function booleanVariant<TName extends string>(
   name: TName,
+  /** Strip the prop from HTML element? */
   stripProp: boolean,
 ): {
   [K in TName]?: boolean;
@@ -18,10 +19,30 @@ export function booleanVariant<TName extends string>(
 }
 
 /**
+ * Creates a number prop for component
+ */
+export function numberProp<TName extends string>(
+  name: TName,
+  /** Strip the prop from HTML element? */
+  stripProp: boolean,
+  defaultValue?: number,
+): {
+  [K in TName]?: number;
+} {
+  return {
+    prop: name,
+    name: name.toLowerCase(),
+    stripProp,
+    defaultValue,
+  } as any;
+}
+
+/**
  * Creates variant settings for component
  */
 export function variant<TName extends string, TVariants extends readonly any[]>(
   name: TName,
+  /** Strip the prop from HTML element? */
   stripProp: boolean,
   // eslint-disable-next-line
   variants: TVariants,


### PR DESCRIPTION
This PR introduces these changes to Drawer:

- focus trap
- body scroll lock (if Drawer has `backdrop` enabled)
- auto focus element on open (if `focusElementRef` is provided)

Closes #163 