### PR TITLE
Use exclusive media query breakpoints

### DIFF
--- a/packages/visage/src/ResponsiveDesignSystem.tsx
+++ b/packages/visage/src/ResponsiveDesignSystem.tsx
@@ -20,9 +20,10 @@ import { createEmotionStyleGenerator } from './emotionStyleGenerator';
 
 const defaultStyleGenerator = createEmotionStyleGenerator();
 
-const MOBILE_BP = `only screen`; // 40em
-const TABLET_BP = `screen and (min-width: ${641 / 16}em)`; // 40.0625em
-const DESKTOP_BP = `screen and (min-width: ${1025 / 16}em)`; // 64.036em
+// https://zellwk.com/blog/media-query-units/
+const MOBILE_BP = `(max-width: ${767 / 16}em)`;
+const TABLET_BP = `(min-width: ${768 / 16}em) and (max-width: ${1024 / 16}em)`;
+const DESKTOP_BP = `(min-width: ${1025 / 16}em)`;
 
 const defaultBreakpoints = [MOBILE_BP, TABLET_BP, DESKTOP_BP];
 


### PR DESCRIPTION
This PR introduces exclusive media queries with modified breakpoints.

For mobile we use `max-width: 767px`
For tablet we use `min-width: 768px and max-width: 1024px`
For desktop we use `min-width: 1025px`

All media queries use `em` so they work correctly with `zoom` and browser `font-size` change.

Closes #252 