### PR TITLE
Remove scrollbar from Toggle in IE11

### DIFF
--- a/packages/visage-docs/src/components/CodeBlock.tsx
+++ b/packages/visage-docs/src/components/CodeBlock.tsx
@@ -15,6 +15,7 @@ import React, {
 import { LiveEditor, LiveError, LivePreview, LiveProvider } from 'react-live';
 import * as DSScope from '@byteclaw/visage';
 import * as Core from '@byteclaw/visage-core';
+import { createDocsTheme } from '@byteclaw/visage-themes';
 import * as Utilities from '@byteclaw/visage-utils';
 import { ThemeTogglerContext } from '../theme';
 import { WithRef } from './WithRef';
@@ -35,6 +36,7 @@ const Scope = {
   useCallback,
   WithRef,
   WithState,
+  theme: createDocsTheme(),
 };
 
 const EditorError = createComponent(LiveError, {

--- a/packages/visage/src/components/Toggle.tsx
+++ b/packages/visage/src/components/Toggle.tsx
@@ -26,8 +26,7 @@ import {
 const ToggleContainer = createComponent('div', {
   displayName: 'ToggleContainer',
   styles: {
-    overflowX: 'hidden',
-    overflowY: 'visible',
+    overflow: 'hidden',
     borderRadius: 999,
     width: 'auto',
     display: 'inline-flex',


### PR DESCRIPTION
This PR removes scrollbar from Toggle in IE11 and fixes missing `theme` in `react-live` scope that broke `IfViewport` documentation.

Closes #306 