### PR TITLE
fix(visage): normalize Esc to Escape because IE11 does not use standard

### DIFF
--- a/packages/visage-docs/gatsby-node.js
+++ b/packages/visage-docs/gatsby-node.js
@@ -33,6 +33,10 @@ exports.onCreateWebpackConfig = function onCreateWebpackConfig({
           ],
           use: [loaders.js()],
         },
+        {
+          test: /react-refresh-webpack-plugin/,
+          use: [loaders.js()],
+        },
       ],
     },
   });

--- a/packages/visage/src/components/CloseListenerManager.tsx
+++ b/packages/visage/src/components/CloseListenerManager.tsx
@@ -9,6 +9,7 @@ import React, {
   useRef,
 } from 'react';
 import { useStaticEffect } from '../hooks';
+import { normalizeKeyboardEventKey } from './shared';
 
 export type OnCloseHandler = (
   e: KeyboardEvent | MouseEvent,
@@ -66,7 +67,7 @@ function onEscapeKeyUpHandlerCreator(
 ) {
   return (e: KeyboardEvent) => {
     if (
-      e.key === 'Escape' &&
+      normalizeKeyboardEventKey(e) === 'Escape' &&
       escapeStack.current &&
       escapeStack.current.length > 0
     ) {

--- a/packages/visage/src/components/shared/normalizeKeyboardEventKey.ts
+++ b/packages/visage/src/components/shared/normalizeKeyboardEventKey.ts
@@ -1,10 +1,17 @@
-import { KeyboardEvent } from 'react';
+import { KeyboardEvent as ReactKeyboardEvent } from 'react';
 
-export function normalizeKeyboardEventKey(event: KeyboardEvent): string {
+export function normalizeKeyboardEventKey(
+  event: ReactKeyboardEvent | KeyboardEvent,
+): string {
   const { key, keyCode } = event;
 
   if (keyCode >= 37 && keyCode <= 40 && key.indexOf('Arrow') !== 0) {
     return `Arrow${key}`;
   }
+
+  if (key === 'Esc') {
+    return 'Escape';
+  }
+
   return key;
 }


### PR DESCRIPTION
This PR fixes <kbd>Escape</kbd> keyup handlers because IE11 uses `Esc` as a `e.key` instead of `Escape`.

Also this PR fixes gatsby dev mode in IE11.

Closes #371 