### PR TITLE
fix(visage/core): use previous breakpoint if no breakpoints are matched

### DIFF
--- a/packages/visage-core/src/useBreakpointManager.ts
+++ b/packages/visage-core/src/useBreakpointManager.ts
@@ -36,13 +36,20 @@ function reducer(
     const matches = previousState.matches.slice();
     matches[action.index] = action.matches;
 
+    const greatestBreakpoint = matches.lastIndexOf(true);
+
     return {
       matches,
-      viewport: matches.lastIndexOf(true),
+      // if there is no breakpoint matched at the moment, use the old one
+      // this is an edge case if you use exclusive media queries where only one is matched at the time
+      // in that case it can happen that first is a breakpoint unset and then is set for new one
+      // this breaks the application so we use previous viewport to be sure
+      viewport:
+        greatestBreakpoint === -1 ? previousState.viewport : greatestBreakpoint,
     };
   }
 
-  throw new Error('Unknown action');
+  return previousState;
 }
 
 export function useBreakpointManager(


### PR DESCRIPTION
This PR fixes a scenario where user is resizing the window and uses exclusive media queries. Basically there could be situations where no breakpoint was matched because we first unset the lower one and then on next render set the greater one. But in the meantime there was no breakpoint at all which breaks the application.

Now we use previous breakpoint if there is no breakpoint set.

Closes #373 