### PR TITLE
Fix dark theme initial render

### DIFF
--- a/packages/visage-docs/gatsby-browser.js
+++ b/packages/visage-docs/gatsby-browser.js
@@ -1,3 +1,5 @@
+// import ReactDOM from 'react-dom';
+
 export { wrapRootElement } from './src';
 
 let offsetY = 0;
@@ -30,3 +32,13 @@ export const shouldUpdateScroll = ({ routerProps: { location } }) => {
   const offset = getTargetOffset(location.hash);
   return offset !== null ? [0, offset] : true;
 };
+
+/* export const replaceHydrateFunction = () => {
+  return (element, container, callback) => {
+    // replace hydrate with render because hydrate does not pick up
+    // dark theme settings and causes weird render where Sidebar is white
+    // but the rest of page is dark
+    // see https://reactjs.org/docs/react-dom.html#hydrate
+    ReactDOM.render(element, container, callback);
+  };
+}; */

--- a/packages/visage-docs/src/components/DesignSystem.tsx
+++ b/packages/visage-docs/src/components/DesignSystem.tsx
@@ -3,7 +3,13 @@ import {
   createDocsTheme,
   docsThemeColorPalette,
 } from '@byteclaw/visage-themes';
-import React, { useCallback, useMemo, useState, ReactNode } from 'react';
+import React, {
+  useCallback,
+  useMemo,
+  useState,
+  ReactNode,
+  useEffect,
+} from 'react';
 import store from 'store2';
 import { ThemeTogglerContext, toggleColorPaletteMode } from '../theme';
 import { visageDocsFaces } from '../visageDocsFaces';
@@ -14,14 +20,12 @@ interface DesignSystemProps {
   children: ReactNode;
 }
 
-export function DesignSystem({ children }: DesignSystemProps) {
-  const initIsDarkMode = store.get(STORAGE_KEY_DARK_MODE, false);
-  const [isDark, setDarkTheme] = useState(initIsDarkMode);
+const initIsDarkMode = store.get(STORAGE_KEY_DARK_MODE, false);
 
+export function DesignSystem({ children }: DesignSystemProps) {
+  const [isDark, setDarkTheme] = useState(false);
   const [colors, setColorPalette] = useState<ColorPalette>(
-    initIsDarkMode
-      ? toggleColorPaletteMode(docsThemeColorPalette)
-      : docsThemeColorPalette,
+    docsThemeColorPalette,
   );
   const theme = useMemo(() => {
     return createDocsTheme({
@@ -35,6 +39,15 @@ export function DesignSystem({ children }: DesignSystemProps) {
     setColorPalette(toggleColorPaletteMode(colors));
     store.set(STORAGE_KEY_DARK_MODE, !isDark);
   }, [colors, isDark]);
+
+  useEffect(() => {
+    // set up the theme by local storage in new render pass because
+    // React.hydrate used by gatsby does not pick up theme correctly (which is correct behaviour)
+    // see https://reactjs.org/docs/react-dom.html#hydrate
+    if (initIsDarkMode && !isDark) {
+      togglePaletteMode();
+    }
+  }, []);
 
   return (
     <ResponsiveDesignSystem theme={theme}>

--- a/packages/visage/src/components/Drawer.tsx
+++ b/packages/visage/src/components/Drawer.tsx
@@ -161,7 +161,7 @@ export function Drawer({
 
   if (relative) {
     return (
-      <BaseDrawer relative={relative} {...restProps}>
+      <BaseDrawer id={outerId} relative={relative} {...restProps}>
         {children}
       </BaseDrawer>
     );


### PR DESCRIPTION
This PR introduces 2 pass render in documentation to pick up dark theme settings from local storage.

Closes #421 