### PR TITLE
feat(visage): allow to define multiple onClose prevent refs

### DIFF
--- a/packages/visage-docs/src/__tests__/__snapshots__/extractTypeInformation.test.ts.snap
+++ b/packages/visage-docs/src/__tests__/__snapshots__/extractTypeInformation.test.ts.snap
@@ -62026,7 +62026,7 @@ Object {
       "isOptional": true,
       "name": "anchor",
       "parent": "MenuProps",
-      "type": "HTMLElement | RefObject<HTMLElement> | null | undefined",
+      "type": "RefObject<HTMLElement> | null | undefined",
     },
     Object {
       "documentation": "",
@@ -65873,6 +65873,15 @@ Default is dialog (you don't need users immediate action)",
       "name": "focusElementRef",
       "parent": "ModalProps",
       "type": "MutableRefObject<HTMLElement | null> | undefined",
+    },
+    Object {
+      "documentation": "Extra elements that should not propagate onClose when click away is enabled
+
+This prop is immutable so make sure you don't use a new array because only first one is being used",
+      "isOptional": true,
+      "name": "preventCloseRefs",
+      "parent": "ModalProps",
+      "type": "MutableRefObject<HTMLElement | null>[] | undefined",
     },
     Object {
       "documentation": "Should we allow to scroll document body?",

--- a/packages/visage-docs/src/docs/components/navigation/menu.mdx
+++ b/packages/visage-docs/src/docs/components/navigation/menu.mdx
@@ -26,7 +26,7 @@ function Example() {
         aria-controls="buttons-menu"
         aria-haspopup="menu"
         aria-expanded={open}
-        onClick={() => setOpen(true)}
+        onClick={() => setOpen(!open)}
         ref={anchorRef}
       >
         Pop me
@@ -89,7 +89,7 @@ function Example() {
         aria-controls="buttons-menu"
         aria-haspopup="menu"
         aria-expanded={open}
-        onClick={() => setOpen(true)}
+        onClick={() => setOpen(!open)}
         ref={anchorRef}
       >
         {open ? 'Close' : 'Pop up'}

--- a/packages/visage-docs/src/docs/components/overlays/popover.mdx
+++ b/packages/visage-docs/src/docs/components/overlays/popover.mdx
@@ -20,7 +20,7 @@ function Example() {
 
   return (
     <Fragment>
-      <Button onClick={() => setOpen(true)} ref={anchorRef} type="button">
+      <Button onClick={() => setOpen(!open)} ref={anchorRef} type="button">
         Show popover
       </Button>
       <Popover

--- a/packages/visage/src/components/Drawer.tsx
+++ b/packages/visage/src/components/Drawer.tsx
@@ -85,7 +85,7 @@ function bindOnCloseListeners(
 
   // if drawer is open, register close listeners
   const unregisterClickAway = closeListenerManager.registerClickAwayListener(
-    baseRef,
+    [baseRef],
     onClose,
     isFullscreen,
   );

--- a/packages/visage/src/components/Menu.tsx
+++ b/packages/visage/src/components/Menu.tsx
@@ -44,7 +44,7 @@ const MenuItemBase = createComponent(ListItem, {
 });
 
 interface MenuProps extends ExtractVisageComponentProps<typeof MenuBase> {
-  anchor?: null | HTMLElement | RefObject<HTMLElement>;
+  anchor?: null | RefObject<HTMLElement>;
   anchorOrigin?: TransformOriginSettings;
   baseRef?: RefObject<HTMLDivElement>;
   /**

--- a/packages/visage/src/components/Modal.tsx
+++ b/packages/visage/src/components/Modal.tsx
@@ -51,6 +51,7 @@ const BaseModal = createComponent('div', {
 function bindOnCloseListeners(
   open: boolean,
   closeListenerManagerContext: CloseListenerManagerContextAPI,
+  preventCloseRefs: RefObject<HTMLElement>[],
   modalRef: RefObject<HTMLElement>,
   isFullscreen: boolean,
   onClose: undefined | (() => void),
@@ -64,7 +65,7 @@ function bindOnCloseListeners(
   const unregisterClickAway = disableOnClickAwayClose
     ? () => {}
     : closeListenerManagerContext.registerClickAwayListener(
-        modalRef,
+        [modalRef, ...preventCloseRefs],
         onClose,
         isFullscreen,
       );
@@ -115,6 +116,12 @@ interface ModalProps {
    */
   focusElementRef?: MutableRefObject<HTMLElement | null>;
   /**
+   * Extra elements that should not propagate onClose when click away is enabled
+   *
+   * This prop is immutable so make sure you don't use a new array because only first one is being used
+   */
+  preventCloseRefs?: MutableRefObject<HTMLElement | null>[];
+  /**
    * Should we allow to scroll document body?
    */
   unlockBodyScroll?: boolean;
@@ -137,6 +144,7 @@ export function Modal({
   onClose,
   open = true,
   focusElementRef,
+  preventCloseRefs = [],
   scrollable = false,
 }: ModalProps) {
   const id = useUniqueId(outerId, 'modal-portal');
@@ -150,6 +158,8 @@ export function Modal({
     bindOnCloseListeners,
     open,
     closeListenerManagerContext,
+    // this one is not picked up on update so be careful
+    preventCloseRefs,
     contentRef || modalRef,
     backdrop,
     onClose,

--- a/packages/visage/src/components/Popover.tsx
+++ b/packages/visage/src/components/Popover.tsx
@@ -54,7 +54,7 @@ export const BasePopover = createComponent('div', {
 interface PopoverProps extends ExtractVisageComponentProps<typeof BasePopover> {
   allowScrolling?: boolean;
   alwaysVisible?: boolean;
-  anchor?: null | HTMLElement | RefObject<HTMLElement>;
+  anchor?: null | RefObject<HTMLElement>;
   anchorOrigin?: TransformOriginSettings;
   anchorPosition?: { top: number; left: number };
   anchorReference?: 'anchor' | 'anchorPosition' | 'none';
@@ -140,6 +140,7 @@ export function Popover({
 
   const contentRef = useRef<HTMLDivElement | null>(null);
   const handleResizeRef = useRef(() => {});
+  const preventCloseRefs = useRef(anchor ? [anchor] : []);
   const { zIndex } = useLayerManager();
 
   const getAnchorOffset = useCallback(
@@ -398,6 +399,7 @@ export function Popover({
       onClose={onClose}
       open={open}
       contentRef={contentRef}
+      preventCloseRefs={preventCloseRefs.current}
     >
       <BasePopover
         {...restProps}

--- a/packages/visage/src/components/__tests__/CloseListenerManager.test.tsx
+++ b/packages/visage/src/components/__tests__/CloseListenerManager.test.tsx
@@ -27,7 +27,7 @@ function RenderClosable({
       onClose,
     );
     const unregisterClick = closeListenerManager.registerClickAwayListener(
-      divRef,
+      [divRef],
       onClose,
       isFullscreen,
     );


### PR DESCRIPTION
This PR introduces a way to define multiple element refs to `CloseListenerManager` click away listener that can be used to prevent click away. Be careful, the value is not mutable.

This is useful for example in `Menu` if you want to create a Dropdown button that can open/close the `Menu`.

Closes #383 