### PR TITLE
refactor(visage): remove textinput color from theme

### DIFF
--- a/packages/visage-docs/src/components/ThemeEditor.tsx
+++ b/packages/visage-docs/src/components/ThemeEditor.tsx
@@ -216,10 +216,7 @@ const colorNamesWithText: (keyof ColorPalette)[] = [
   'warning',
 ];
 
-const colorNamesWithoutText: (keyof ColorPalette)[] = [
-  'textInput',
-  'textInputBorder',
-];
+const colorNamesWithoutText: (keyof ColorPalette)[] = [];
 
 interface ThemeEditorProps {
   onClose: () => void;

--- a/packages/visage-docs/src/theme.ts
+++ b/packages/visage-docs/src/theme.ts
@@ -1,5 +1,4 @@
 import { ColorPalette } from '@byteclaw/visage';
-import color from 'color';
 import { createContext } from 'react';
 
 export const ThemeTogglerContext = createContext<{
@@ -18,12 +17,5 @@ export function toggleColorPaletteMode(palette: ColorPalette): ColorPalette {
     darkShadesText: palette.shadesText,
     shades: palette.darkShades,
     shadesText: palette.darkShadesText,
-    // if default colors are same, calculate these
-    textInput: color(palette.darkShades)
-      .lighten(0.3)
-      .toString(),
-    textInputBorder: color(palette.darkShades)
-      .darken(0.3)
-      .toString(),
   };
 }

--- a/packages/visage-themes/README.md
+++ b/packages/visage-themes/README.md
@@ -70,10 +70,6 @@ const theme = createNPointModularScaleTheme({
     /** Uses as background for success elements or as success text color */
     success: 'green';
     successText: 'white';
-    /** Text input backgrounds */
-    textInput: 'white';
-    /** Text input border colors */
-    textInputBorder: '#999';
     /** Uses as background for warning elements or as warning text color */
     warning: 'orange';
     warningText: 'white';
@@ -146,10 +142,6 @@ const theme = createNPointFontScaleTheme({
     /** Uses as background for success elements or as success text color */
     success: 'green';
     successText: 'white';
-    /** Text input backgrounds */
-    textInput: 'white';
-    /** Text input border colors */
-    textInputBorder: '#999';
     /** Uses as background for warning elements or as warning text color */
     warning: 'orange';
     warningText: 'white';

--- a/packages/visage-themes/src/__tests__/nPointFontScale.test.ts
+++ b/packages/visage-themes/src/__tests__/nPointFontScale.test.ts
@@ -24,8 +24,6 @@ describe('NPoint font scale theme', () => {
       primaryText: 'white',
       success: 'green',
       successText: 'white',
-      textInput: 'white',
-      textInputBorder: 'black',
       warning: 'orange',
       warningText: 'white',
     },

--- a/packages/visage-themes/src/__tests__/nPointModularScale.test.ts
+++ b/packages/visage-themes/src/__tests__/nPointModularScale.test.ts
@@ -36,8 +36,6 @@ describe('NPoint modular scale theme', () => {
       primaryText: 'white',
       success: 'green',
       successText: 'white',
-      textInput: 'white',
-      textInputBorder: 'black',
       warning: 'orange',
       warningText: 'white',
     },

--- a/packages/visage-themes/src/docs.ts
+++ b/packages/visage-themes/src/docs.ts
@@ -22,8 +22,6 @@ export const docsThemeColorPalette: ColorPalette = {
   ...generateColorScale<'danger' | 'dangerText'>('danger', '#c0392b', 5, 5),
   ...generateColorScale<'info' | 'infoText'>('info', '#2980b9', 5, 5),
   ...generateColorScale<'warning' | 'warningText'>('warning', '#f1c40f', 5, 5),
-  textInput: shades.lighten(0.3).toString(),
-  textInputBorder: shades.darken(0.3).toString(),
 };
 
 export interface DocsThemeSettings {

--- a/packages/visage/src/__tests__/TestDesignSystem.tsx
+++ b/packages/visage/src/__tests__/TestDesignSystem.tsx
@@ -38,8 +38,6 @@ export function createTestTheme(faces?: VisageFaces) {
       neutralText: '#000',
       success: 'green',
       successText: 'white',
-      textInput: 'white',
-      textInputBorder: 'black',
       warning: 'orange',
       warningText: 'white',
     },

--- a/packages/visage/src/components/Checkbox.tsx
+++ b/packages/visage/src/components/Checkbox.tsx
@@ -72,7 +72,7 @@ const CheckboxToggler = createComponent(Flex, {
         styles={{
           width: '1em',
           height: '1em',
-          stroke: 'textInput',
+          stroke: 'color(shades tint(10%))',
           strokeWidth: '2px',
           fill: 'none',
         }}
@@ -82,7 +82,7 @@ const CheckboxToggler = createComponent(Flex, {
     ),
   },
   styles: {
-    backgroundColor: 'textInput',
+    backgroundColor: 'color(shades tint(10%))',
     alignSelf: 'center',
     transition: 'all 150ms',
     borderColor: 'accent',

--- a/packages/visage/src/components/FileInput.tsx
+++ b/packages/visage/src/components/FileInput.tsx
@@ -54,8 +54,8 @@ const FileInputControl = createComponent('div', {
     '&[data-draggedover="true"]': {
       boxShadow: createSurfaceFocusShadow(),
     },
-    backgroundColor: 'textInput',
-    borderColor: 'textInputBorder',
+    backgroundColor: 'color(shades tint(10%))',
+    borderColor: 'color(shades shade(30%))',
     borderStyle: 'solid',
     borderWidth: '1px',
     borderRadius: 'controlBorderRadius',

--- a/packages/visage/src/components/Radio.tsx
+++ b/packages/visage/src/components/Radio.tsx
@@ -93,7 +93,7 @@ const RadioToggler = createComponent(Flex, {
         color: 'primaryText',
         borderColor: 'primary',
         '& > svg': {
-          fill: 'textInput',
+          fill: 'color(shades tint(10%))',
           visibility: 'visible',
         },
       },

--- a/packages/visage/src/components/TextArea.tsx
+++ b/packages/visage/src/components/TextArea.tsx
@@ -30,8 +30,7 @@ const TextAreaBaseControl = createComponent('textarea', {
     ...(props.disabled ? disabledControlStyles : {}),
     ...(props.invalid ? invalidControlStyles : {}),
     '::placeholder': {
-      color: 'currentColor',
-      opacity: 0.3,
+      color: 'color(shadesText alpha(0.3))',
     },
   }),
   variants: [disabledControlBooleanVariant, invalidControlBooleanVariant],

--- a/packages/visage/src/components/TextInput.tsx
+++ b/packages/visage/src/components/TextInput.tsx
@@ -21,8 +21,8 @@ import {
 } from './shared';
 
 export const TextInputBaseStyles: VisageStyleSheet = {
-  backgroundColor: 'textInput',
-  borderColor: 'textInputBorder',
+  backgroundColor: 'color(shades tint(10%))',
+  borderColor: 'color(shades shade(30%))',
   borderStyle: 'solid',
   borderWidth: '1px',
   borderRadius: 'controlBorderRadius',

--- a/packages/visage/src/components/Toggle.tsx
+++ b/packages/visage/src/components/Toggle.tsx
@@ -78,7 +78,8 @@ const ToggleControl = createComponent('input', {
       left: '-50%',
     },
     '& + div': {
-      backgroundColor: 'neutral',
+      backgroundColor:
+        'color(shades if(isDark color(shades tint(10%)) color(shades shade(10%))))',
       transitionProperty: 'all',
       transitionDuration: '0.2s',
       transitionTimingFunction: 'ease-out',

--- a/packages/visage/src/components/__tests__/FileInput.test.tsx
+++ b/packages/visage/src/components/__tests__/FileInput.test.tsx
@@ -63,8 +63,8 @@ describe('FileInput', () => {
       }
 
       .emotion-1 {
-        background-color: rgb(255,255,255);
-        border-color: rgb(0,0,0);
+        background-color: rgb(209,209,209);
+        border-color: rgb(143,143,143);
         border-style: solid;
         border-width: 1px;
         border-radius: 4px;
@@ -170,8 +170,8 @@ describe('FileInput', () => {
       }
 
       .emotion-1 {
-        background-color: rgb(255,255,255);
-        border-color: rgb(0,0,0);
+        background-color: rgb(209,209,209);
+        border-color: rgb(143,143,143);
         border-style: solid;
         border-width: 1px;
         border-radius: 4px;
@@ -286,8 +286,8 @@ describe('FileInput', () => {
       }
 
       .emotion-1 {
-        background-color: rgb(255,255,255);
-        border-color: rgb(0,0,0);
+        background-color: rgb(209,209,209);
+        border-color: rgb(143,143,143);
         border-style: solid;
         border-width: 1px;
         border-radius: 4px;
@@ -449,8 +449,8 @@ describe('FileInput', () => {
       }
 
       .emotion-1 {
-        background-color: rgb(255,255,255);
-        border-color: rgb(0,0,0);
+        background-color: rgb(209,209,209);
+        border-color: rgb(143,143,143);
         border-style: solid;
         border-width: 1px;
         border-radius: 10px;

--- a/packages/visage/src/components/__tests__/Toggle.test.tsx
+++ b/packages/visage/src/components/__tests__/Toggle.test.tsx
@@ -168,7 +168,7 @@ describe('Toggle', () => {
       }
 
       .emotion-0 + div {
-        background-color: rgb(238,238,238);
+        background-color: rgb(184,184,184);
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -378,7 +378,7 @@ describe('Toggle', () => {
       }
 
       .emotion-0 + div {
-        background-color: rgb(238,238,238);
+        background-color: rgb(184,184,184);
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -589,7 +589,7 @@ describe('Toggle', () => {
       }
 
       .emotion-0 + div {
-        background-color: rgb(238,238,238);
+        background-color: rgb(184,184,184);
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -799,7 +799,7 @@ describe('Toggle', () => {
       }
 
       .emotion-0 + div {
-        background-color: rgb(238,238,238);
+        background-color: rgb(184,184,184);
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -1077,7 +1077,7 @@ describe('Toggle', () => {
       }
 
       .emotion-0 + div {
-        background-color: rgb(238,238,238);
+        background-color: rgb(184,184,184);
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;
@@ -1221,7 +1221,7 @@ describe('Toggle', () => {
       }
 
       .emotion-0 + div {
-        background-color: rgb(238,238,238);
+        background-color: rgb(184,184,184);
         -webkit-transition-property: all;
         transition-property: all;
         -webkit-transition-duration: 0.2s;

--- a/packages/visage/src/components/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/visage/src/components/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Checkbox is extendable by CheckboxControl face 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  background-color: rgb(255,255,255);
+  background-color: rgb(209,209,209);
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
@@ -70,7 +70,7 @@ exports[`Checkbox is extendable by CheckboxControl face 1`] = `
 .emotion-1 {
   width: 1em;
   height: 1em;
-  stroke: rgb(255,255,255);
+  stroke: rgb(209,209,209);
   stroke-width: 2px;
   fill: none;
 }
@@ -197,7 +197,7 @@ exports[`Checkbox is extendable by CheckboxLabel face 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  background-color: rgb(255,255,255);
+  background-color: rgb(209,209,209);
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
@@ -239,7 +239,7 @@ exports[`Checkbox is extendable by CheckboxLabel face 1`] = `
 .emotion-1 {
   width: 1em;
   height: 1em;
-  stroke: rgb(255,255,255);
+  stroke: rgb(209,209,209);
   stroke-width: 2px;
   fill: none;
 }
@@ -353,7 +353,7 @@ exports[`Checkbox is extendable by CheckboxLabelText face 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  background-color: rgb(255,255,255);
+  background-color: rgb(209,209,209);
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
@@ -395,7 +395,7 @@ exports[`Checkbox is extendable by CheckboxLabelText face 1`] = `
 .emotion-1 {
   width: 1em;
   height: 1em;
-  stroke: rgb(255,255,255);
+  stroke: rgb(209,209,209);
   stroke-width: 2px;
   fill: none;
 }
@@ -507,7 +507,7 @@ exports[`Checkbox is extendable by CheckboxToggler face 1`] = `
 .emotion-1 {
   width: 1em;
   height: 1em;
-  stroke: rgb(255,255,255);
+  stroke: rgb(209,209,209);
   stroke-width: 2px;
   fill: none;
 }
@@ -547,7 +547,7 @@ exports[`Checkbox is extendable by CheckboxToggler face 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  background-color: rgb(255,255,255);
+  background-color: rgb(209,209,209);
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
@@ -664,7 +664,7 @@ exports[`Checkbox is extendable by styles 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  background-color: rgb(255,255,255);
+  background-color: rgb(209,209,209);
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
@@ -706,7 +706,7 @@ exports[`Checkbox is extendable by styles 1`] = `
 .emotion-1 {
   width: 1em;
   height: 1em;
-  stroke: rgb(255,255,255);
+  stroke: rgb(209,209,209);
   stroke-width: 2px;
   fill: none;
 }
@@ -820,7 +820,7 @@ exports[`Checkbox renders correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  background-color: rgb(255,255,255);
+  background-color: rgb(209,209,209);
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
@@ -862,7 +862,7 @@ exports[`Checkbox renders correctly 1`] = `
 .emotion-1 {
   width: 1em;
   height: 1em;
-  stroke: rgb(255,255,255);
+  stroke: rgb(209,209,209);
   stroke-width: 2px;
   fill: none;
 }

--- a/packages/visage/src/components/__tests__/__snapshots__/Radio.test.tsx.snap
+++ b/packages/visage/src/components/__tests__/__snapshots__/Radio.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`Radio is extendable by RadioControl face 1`] = `
 }
 
 .emotion-2[data-checked="true"] > svg {
-  fill: rgb(255,255,255);
+  fill: rgb(209,209,209);
   visibility: visible;
 }
 
@@ -217,7 +217,7 @@ exports[`Radio is extendable by RadioLabel face 1`] = `
 }
 
 .emotion-2[data-checked="true"] > svg {
-  fill: rgb(255,255,255);
+  fill: rgb(209,209,209);
   visibility: visible;
 }
 
@@ -373,7 +373,7 @@ exports[`Radio is extendable by RadioLabelText face 1`] = `
 }
 
 .emotion-2[data-checked="true"] > svg {
-  fill: rgb(255,255,255);
+  fill: rgb(209,209,209);
   visibility: visible;
 }
 
@@ -564,7 +564,7 @@ exports[`Radio is extendable by RadioToggler face 1`] = `
 }
 
 .emotion-2[data-checked="true"] > svg {
-  fill: rgb(255,255,255);
+  fill: rgb(209,209,209);
   visibility: visible;
 }
 
@@ -684,7 +684,7 @@ exports[`Radio is extendable by styles 1`] = `
 }
 
 .emotion-2[data-checked="true"] > svg {
-  fill: rgb(255,255,255);
+  fill: rgb(209,209,209);
   visibility: visible;
 }
 
@@ -840,7 +840,7 @@ exports[`Radio renders correctly 1`] = `
 }
 
 .emotion-2[data-checked="true"] > svg {
-  fill: rgb(255,255,255);
+  fill: rgb(209,209,209);
   visibility: visible;
 }
 

--- a/packages/visage/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/visage/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -24,8 +24,8 @@ exports[`TextInput is extendable by InputExtraElement face 1`] = `
     data-toastmanager="true"
   />
   .emotion-3 {
-  background-color: rgb(255,255,255);
-  border-color: rgb(0,0,0);
+  background-color: rgb(209,209,209);
+  border-color: rgb(143,143,143);
   border-style: solid;
   border-width: 1px;
   border-radius: 4px;
@@ -287,8 +287,8 @@ exports[`TextInput is extendable by TextInputBase face 1`] = `
 }
 
 .emotion-2 {
-  background-color: rgb(255,255,255);
-  border-color: rgb(0,0,0);
+  background-color: rgb(209,209,209);
+  border-color: rgb(143,143,143);
   border-style: solid;
   border-width: 1px;
   border-radius: 10px;
@@ -358,8 +358,8 @@ exports[`TextInput is extendable by TextInputControl face 1`] = `
     data-toastmanager="true"
   />
   .emotion-2 {
-  background-color: rgb(255,255,255);
-  border-color: rgb(0,0,0);
+  background-color: rgb(209,209,209);
+  border-color: rgb(143,143,143);
   border-style: solid;
   border-width: 1px;
   border-radius: 4px;
@@ -509,8 +509,8 @@ exports[`TextInput is extendable by TextInputControlBase face 1`] = `
     data-toastmanager="true"
   />
   .emotion-2 {
-  background-color: rgb(255,255,255);
-  border-color: rgb(0,0,0);
+  background-color: rgb(209,209,209);
+  border-color: rgb(143,143,143);
   border-style: solid;
   border-width: 1px;
   border-radius: 4px;
@@ -656,8 +656,8 @@ exports[`TextInput render correctly 1`] = `
     data-toastmanager="true"
   />
   .emotion-2 {
-  background-color: rgb(255,255,255);
-  border-color: rgb(0,0,0);
+  background-color: rgb(209,209,209);
+  border-color: rgb(143,143,143);
   border-style: solid;
   border-width: 1px;
   border-radius: 4px;

--- a/packages/visage/src/types.ts
+++ b/packages/visage/src/types.ts
@@ -20,10 +20,6 @@ export interface ColorPalette {
   /** Uses as background for success elements or as success text color */
   success: string | ScaleValue<string>;
   successText: string | ScaleValue<string>;
-  /** Text input backgrounds */
-  textInput: string | ScaleValue<string>;
-  /** Text input border colors */
-  textInputBorder: string | ScaleValue<string>;
   /** Uses as background for warning elements or as warning text color */
   warning: string | ScaleValue<string>;
   warningText: string | ScaleValue<string>;


### PR DESCRIPTION
This PR removes `textInput` and `textInputBorder` from theme color palette.

Closes #431 