### PR TITLE
Use mouse down to open AutocompleteInput and Select

### DIFF
--- a/packages/visage/src/components/__tests__/AutocompleteInput.test.tsx
+++ b/packages/visage/src/components/__tests__/AutocompleteInput.test.tsx
@@ -70,7 +70,7 @@ describe('AutocompleteInput', () => {
         />,
       );
 
-      // now open focus using click
+      // focus
       fireEvent.click(getByTestId('input'));
 
       // type something
@@ -291,8 +291,8 @@ describe('AutocompleteInput', () => {
         />,
       );
 
-      // now open focus using click
-      fireEvent.click(getByTestId('input'));
+      // now open using mouse down
+      fireEvent.mouseDown(getByTestId('input'));
 
       expect(onLoadOptions).toHaveBeenCalledTimes(1);
       expect(onLoadOptions).toHaveBeenCalledWith('');
@@ -382,7 +382,7 @@ describe('AutocompleteInput', () => {
     );
 
     // now open the menu
-    fireEvent.click(getByTestId('input'));
+    fireEvent.mouseDown(getByTestId('input'));
 
     // resolve loading
     await act(() => Promise.resolve());

--- a/packages/visage/src/components/__tests__/Select.test.tsx
+++ b/packages/visage/src/components/__tests__/Select.test.tsx
@@ -18,8 +18,8 @@ describe('Select', () => {
         />,
       );
 
-      // now open focus using click
-      fireEvent.click(document.querySelector('input'));
+      // now open
+      fireEvent.mouseDown(document.querySelector('input'));
 
       // now expect select to be loading options
       expect(onLoadOptions).toHaveBeenCalledTimes(1);
@@ -301,7 +301,7 @@ describe('Select', () => {
       expect(getByTestId('select')).toHaveAttribute('value', '');
 
       // now open select again, and see that options are loaded without filter
-      fireEvent.click(getByTestId('select'));
+      fireEvent.mouseDown(getByTestId('select'));
 
       // now expect select to be loading options
       expect(onLoadOptions).toHaveBeenCalledTimes(3);
@@ -358,8 +358,7 @@ describe('Select', () => {
       // now focus select
       fireEvent.focus(getByTestId('select'));
 
-      // now open focus using ArrowDown
-      fireEvent.click(document.querySelector('input'));
+      fireEvent.mouseDown(document.querySelector('input'));
 
       expect(getByTestId('select').getAttribute('value')).toBe('b');
 
@@ -433,7 +432,7 @@ describe('Select', () => {
     );
 
     // now open the menu
-    fireEvent.click(getByTestId('select'));
+    fireEvent.mouseDown(getByTestId('select'));
 
     // resolve loading
     await act(() => Promise.resolve());
@@ -471,7 +470,7 @@ describe('Select', () => {
     );
 
     // now open the menu
-    fireEvent.click(getByTestId('select'));
+    fireEvent.mouseDown(getByTestId('select'));
 
     // resolve loading
     await act(() => Promise.resolve());


### PR DESCRIPTION
This PR introduces:

**AutocompleteInput** 

- use `onMouseDown` to open if `expandOnClick` is enabled
- composes `onBlur, onMouseDown, onKeyDown` so you can pass these from your app

**Select**

- use `onMouseDown` to open
- composes `onBlur, onMouseDown, onKeyDown` so you can pass these from your app

Closes #438 