### PR TITLE
fix(visage): prevent autofill on AutocompleteInput/Select

### DIFF
--- a/packages/visage/src/components/AutocompleteInput.tsx
+++ b/packages/visage/src/components/AutocompleteInput.tsx
@@ -384,13 +384,16 @@ export const AutocompleteInput: typeof AutocompleteInputComp = forwardRef(
     return (
       <React.Fragment>
         <TextInput
+          autoCorrect="off"
+          autoCapitalize="none"
+          autoComplete="new-password"
+          spellCheck={false}
           {...restProps}
           aria-activedescendant={
             state.isOpen ? optionId(id, state.focusedIndex) : undefined
           }
           aria-autocomplete="list"
           aria-controls={listboxId}
-          autoComplete="off"
           baseProps={{
             ...restProps.baseProps,
             'aria-busy': state.isBusy,

--- a/packages/visage/src/components/Select.tsx
+++ b/packages/visage/src/components/Select.tsx
@@ -437,13 +437,16 @@ export const Select: typeof SelectComp = forwardRef(
     return (
       <React.Fragment>
         <TextInput
+          autoCorrect="off"
+          autoCapitalize="none"
+          autoComplete="new-password"
+          spellCheck={false}
           {...restProps}
           aria-activedescendant={
             state.isOpen ? optionId(id, state.focusedIndex) : undefined
           }
           aria-autocomplete="list"
           aria-controls={listboxId}
-          autoComplete="off"
           baseProps={{
             ...restProps.baseProps,
             'aria-busy': state.isBusy,


### PR DESCRIPTION
This PR tries to solve autofill on AutocompleteInput/Select components by using `autoComplete="new-password"`. The issue might be reopen if the bug is still in Visage.

Chrome is the main problem I think: https://bugs.chromium.org/p/chromium/issues/detail?id=587466

Closes #440 