### PR TITLE
fix(visage): scroll Menu item to view in Autocomplete/Select

### DIFF
--- a/packages/visage/src/components/AutocompleteInput.tsx
+++ b/packages/visage/src/components/AutocompleteInput.tsx
@@ -73,7 +73,7 @@ const AutocompleteInputMenu = createComponent(
       optionToString,
       onSelect,
     }: AutocompleteInputMenuProps) => {
-      const menuBaseRef = useRef(null);
+      const popoverRef = useRef(null);
       const onOptionClick = useHandlerRef((e: MouseEvent<HTMLLIElement>) => {
         onSelect(Number(e.currentTarget.dataset.optionIndex));
       });
@@ -87,18 +87,20 @@ const AutocompleteInputMenu = createComponent(
       // scroll focused item into view
       useStaticEffect(
         scrollAriaSelectedElementToView,
-        menuBaseRef,
+        popoverRef,
         focusedIndex,
       );
 
       return (
         <Menu
           anchor={inputContainerRef}
-          baseRef={menuBaseRef}
           disableEvents
           keepAnchorWidth
           id={listboxId}
           open={open}
+          popoverProps={{
+            popoverRef,
+          }}
           role="listbox"
           tabIndex={-1}
         >

--- a/packages/visage/src/components/Popover.tsx
+++ b/packages/visage/src/components/Popover.tsx
@@ -26,6 +26,7 @@ import {
   useAutofocusOnMount,
   useDebouncedCallback,
   useUniqueId,
+  useCombinedRef,
 } from '../hooks';
 import { useLayerManager } from './LayerManager';
 
@@ -82,6 +83,10 @@ interface PopoverProps extends ExtractVisageComponentProps<typeof BasePopover> {
     | 'top-right'
     | 'bottom-left'
     | 'bottom-right';
+  /**
+   * Ref to div that wraps the popover content
+   */
+  popoverRef?: RefObject<HTMLDivElement>;
   transformOrigin?: TransformOriginSettings;
 }
 
@@ -126,6 +131,7 @@ export function Popover({
   transformOrigin = defaultOrigin,
   onClose = () => {},
   placement = 'bottom',
+  popoverRef,
   ...restProps
 }: PopoverProps) {
   const { breakpoint } = useDesignSystem();
@@ -138,7 +144,7 @@ export function Popover({
     return getResponsiveValue(breakpoint, fullscreen);
   }, [fullscreen, breakpoint]);
 
-  const contentRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useCombinedRef(popoverRef);
   const handleResizeRef = useRef(() => {});
   const preventCloseRefs = useRef(anchor ? [anchor] : []);
   const { zIndex } = useLayerManager();

--- a/packages/visage/src/components/Select.tsx
+++ b/packages/visage/src/components/Select.tsx
@@ -70,7 +70,8 @@ const SelectMenu = createComponent(
       optionToString,
       onSelect,
     }: SelectMenuProps) => {
-      const menuBaseRef = useRef(null);
+      // ref to popover base because we can scroll only scrollable div
+      const popoverRef = useRef(null);
       const onOptionClick = useHandlerRef((e: MouseEvent<HTMLLIElement>) => {
         onSelect(Number(e.currentTarget.dataset.optionIndex));
       });
@@ -84,18 +85,20 @@ const SelectMenu = createComponent(
       // scroll focused item into view
       useStaticEffect(
         scrollAriaSelectedElementToView,
-        menuBaseRef,
+        popoverRef,
         focusedIndex,
       );
 
       return (
         <Menu
           anchor={inputContainerRef}
-          baseRef={menuBaseRef}
           disableEvents
           keepAnchorWidth
           id={listboxId}
           open={open}
+          popoverProps={{
+            popoverRef,
+          }}
           role="listbox"
           tabIndex={-1}
         >

--- a/packages/visage/src/components/effects/index.ts
+++ b/packages/visage/src/components/effects/index.ts
@@ -11,12 +11,27 @@ export function scrollAriaSelectedElementToView(
   // eslint-disable-next-line
   index: number,
 ) {
-  containerRef.current
-    ?.querySelector('[aria-selected="true"]')
-    ?.scrollIntoView({
-      block: 'nearest',
-      inline: 'start',
-    });
+  const { current } = containerRef;
+
+  if (!current) {
+    return;
+  }
+
+  const selectedItem = current.querySelector<HTMLElement>(
+    '[aria-selected="true"]',
+  );
+
+  if (selectedItem) {
+    const containerScrollTop = current.scrollTop;
+    const containerHeight = current.offsetHeight;
+    const isVisible =
+      selectedItem.offsetTop >= containerScrollTop &&
+      selectedItem.offsetTop <= containerScrollTop + containerHeight;
+
+    if (!isVisible) {
+      current.scrollTop = selectedItem.offsetTop;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
This PR introduces simple fix to keep selected option scrolled into view.

Closes #449 