### PR TITLE
fix(visage): allow only one child in Tabs

### DIFF
--- a/packages/visage/src/components/Tabs.tsx
+++ b/packages/visage/src/components/Tabs.tsx
@@ -123,7 +123,9 @@ export function Tab({
 }
 
 interface TabsProps {
-  children: ReactElement<TabProps & BoxProps>[];
+  children:
+    | ReactElement<TabProps & BoxProps>
+    | ReactElement<TabProps & BoxProps>[];
   /**
    * Unique id used to generate references between tabs (accessibility)
    */


### PR DESCRIPTION
Closes #497 