### PR TITLE
Reexport StyleProps and require StyleProps supertype in component markings

### DIFF
--- a/packages/visage-core/src/__tests__/core.test.tsx
+++ b/packages/visage-core/src/__tests__/core.test.tsx
@@ -1,7 +1,13 @@
 /* eslint-disable react/no-multi-comp, react/prefer-stateless-function, max-classes-per-file */
 import React from 'react';
 import { isValidElementType } from 'react-is';
-import { createComponent, displayName, isVisageComponent } from '..';
+import {
+  createComponent,
+  displayName,
+  isVisageComponent,
+  markAsVisageComponent,
+} from '..';
+import { StyleProps } from '../types';
 
 describe('core', () => {
   describe('displayName', () => {
@@ -41,6 +47,32 @@ describe('core', () => {
       expect(isVisageComponent(() => <div />)).toBe(false);
       expect(isVisageComponent(class extends React.Component {})).toBe(false);
       expect(isVisageComponent(createComponent('a'))).toBe(true);
+    });
+  });
+
+  describe('markAsVisageComponent', () => {
+    it('marks functional component as visage component', () => {
+      const C = class extends React.Component<{ test: boolean } & StyleProps> {
+        render() {
+          return <div />;
+        }
+      };
+
+      expect(isVisageComponent(C)).toBe(false);
+      expect(isVisageComponent(markAsVisageComponent(C))).toBe(true);
+    });
+
+    it('marks class component as visage component', () => {
+      const C = () => <div />;
+
+      expect(isVisageComponent(C)).toBe(false);
+      expect(isVisageComponent(markAsVisageComponent(C))).toBe(true);
+    });
+
+    it('does nothing with visage component', () => {
+      const C = createComponent('a');
+
+      expect(isVisageComponent(markAsVisageComponent(C))).toBe(true);
     });
   });
 

--- a/packages/visage-core/src/createComponent.ts
+++ b/packages/visage-core/src/createComponent.ts
@@ -1,5 +1,5 @@
 import { OmitPropsSetting } from '@byteclaw/visage-utils';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { displayName, markAsVisageComponent } from './utils';
 import {
   StyleProps,
@@ -12,8 +12,16 @@ import {
 import { StyleSheet } from './styleSheet';
 import { useVisage, UseVisageHookOptions } from './useVisage';
 
+interface RenderComponentFunctionProps extends StyleProps {
+  children: ReactNode;
+  as: any;
+}
+
 const DEFAULT_STYLE_SHEET = {};
 
+/**
+ * Creates a Visage component
+ */
 export function createComponent<
   TDefaultComponent extends ComponentConstraint,
   TVariants extends {}[] = {}[],
@@ -78,10 +86,7 @@ export function createComponent<
   };
   const defProps = defaultProps || {};
   const RawComponent = (
-    {
-      as = defaultAs,
-      ...restProps
-    }: StyleProps & { as: any; [key: string]: any },
+    { as = defaultAs, ...restProps }: RenderComponentFunctionProps,
     ref: any,
   ) => {
     const props = useVisage(

--- a/packages/visage-core/src/utils.ts
+++ b/packages/visage-core/src/utils.ts
@@ -1,5 +1,5 @@
 import { VisageComponentSymbol } from './constants';
-import { VisageComponent } from './types';
+import { VisageComponent, StyleProps } from './types';
 
 /**
  * Returns a display name of a component
@@ -19,16 +19,13 @@ export function displayName(
 /**
  * Marks a component as Visage component
  */
-export function markAsVisageComponent<
-  T extends
-    | React.ComponentClass
-    | React.FunctionComponent
-    | VisageComponent<any>
->(component: T): T {
+export function markAsVisageComponent<T extends StyleProps>(
+  component: React.ComponentType<T>,
+): VisageComponent<T> {
   // eslint-disable-next-line no-param-reassign
   (component as any)[VisageComponentSymbol] = true;
 
-  return component;
+  return component as any;
 }
 
 /**

--- a/packages/visage/src/index.ts
+++ b/packages/visage/src/index.ts
@@ -5,6 +5,7 @@ export {
   markAsVisageComponent,
   useBreakpoint,
   useDesignSystem,
+  StyleProps,
   Theme,
 } from '@byteclaw/visage-core';
 


### PR DESCRIPTION
Closes #502 

This PR:
- re-exports `StyleProps` from `visage` package
- requires `StyleProps` for all components marked as Visage component using `markAsVisageComponent`