### PR TITLE
fix(visage):  detect breakpoints in effect so app can be hydrated

### DIFF
--- a/packages/visage/src/hooks/useBreakpointDetection.ts
+++ b/packages/visage/src/hooks/useBreakpointDetection.ts
@@ -1,4 +1,4 @@
-import { useOnRenderEffect } from './useOnRenderEffect';
+import { useEffect } from 'react';
 
 /**
  * Sets up breakpoint detection using window.matchMedia API
@@ -8,7 +8,7 @@ export function useBreakpointDetection(
   breakpoints: string[],
   setBreakpoint: (index: number, matches: boolean) => void,
 ) {
-  useOnRenderEffect(() => {
+  return useEffect(() => {
     if (!enabled) {
       return;
     }


### PR DESCRIPTION
Reverts the behaviour of using effect to detect breakpoints with `matchMedia` otherwise SSR hydration is broken.